### PR TITLE
CA-127274: Linux bridge: set forwarding delay to 0 after creating a brid...

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -462,6 +462,7 @@ module Bridge = struct
 					vlan vlan_bug_workaround name)
 			| Bridge ->
 				ignore (Brctl.create_bridge name);
+				Brctl.set_forwarding_delay name 0;
 				Opt.iter (Ip.set_mac name) mac;
 				match vlan with
 				| None -> ()

--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -806,6 +806,8 @@ module Brctl = struct
 		if List.mem name (Sysfs.bridge_to_interfaces bridge) then
 			ignore (call ~log:true ["delif"; bridge; name])
 
+	let set_forwarding_delay bridge time =
+		ignore (call ~log:true ["setfd"; bridge; string_of_int time])
 end
 
 module Ethtool = struct


### PR DESCRIPTION
...ge

The forwarding delay is 30s by default, which means that for the first 30s
after bringing up a bridge port, the port will be in "learning mode", and won't
forward any packets. We want bridge ports to immediately go in "forwarding
mode" instead.

We did this in the past, but it was lost in the transition to xcp-networkd.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
