### PR TITLE
More snapshot-revert fixes

### DIFF
--- a/ocaml/xapi/xapi_vm_clone.ml
+++ b/ocaml/xapi/xapi_vm_clone.ml
@@ -132,7 +132,9 @@ let clone_single_vdi ?(progress) rpc session_id disk_op ~__context vdi driver_pa
 	Client.Task.destroy rpc session_id task;
 	vdi_ref
 
-(* Clone a list of disks, if any error occurs then delete all the ones we've got *)
+(* Clone a list of disks, if any error occurs then delete all the ones we've
+ * got. Reverse the list at the end, so that the disks are returned in the
+ * same order as the [vbds] parameter. *)
 let safe_clone_disks rpc session_id disk_op ~__context vbds driver_params =
 	(* Find the sizes of the disks, and the total size in order to do progress *)
 	let sizes = List.map 
@@ -160,7 +162,7 @@ let safe_clone_disks rpc session_id disk_op ~__context vbds driver_params =
 			delete_disks rpc session_id acc; (* Delete those cloned so far *)
 			raise e
 	in
-	fst (List.fold_left fold_function ([],0L) sizes)
+	List.rev (fst (List.fold_left fold_function ([],0L) sizes))
 
 let power_state_at_snapshot = "power-state-at-snapshot"
 let disk_snapshot_type = "disk-snapshot-type"

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -299,7 +299,7 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 		List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) (vm_suspend_VDI :: vm_disks_with_snapshot);
 		TaskHelper.set_progress ~__context 0.2;
 
-		debug "Cloning the snapshoted disks";
+		debug "Cloning the snapshotted disks";
 		let driver_params = Xapi_vm_clone.make_driver_params () in
 		let cloned_disks = Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone ~__context snap_VBDs_disk driver_params in
 		let cloned_CDs = Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone ~__context snap_VBDs_CD driver_params in

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -286,6 +286,8 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 	(* Filter VBDs to ensure that we don't read empty CDROMs *)
 	let vm_VBDs_disk = List.filter (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk) vm_VBDs in
 	let vm_disks = List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) vm_VBDs_disk in
+	(* Filter out VM disks for which the snapshot does not have a corresponding
+	 * disk - these disks will be left unattached after the revert is complete. *)
 	let vm_disks_with_snapshot = List.filter (fun vdi -> List.mem vdi snap_disks_snapshot_of) vm_disks in
 	let vm_VIFs = Db.VM.get_VIFs ~__context ~self:vm in
 	let vm_VGPUs = Db.VM.get_VGPUs ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -273,7 +273,7 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 	let snap_vbds = Db.VM.get_VBDs ~__context ~self:snapshot in
 	let snap_vbds_disk, snap_vbds_cd =
 		List.partition
-			(fun vbd -> Db.VBD.get_type ~__context ~self:vbd <> `CD)
+			(fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
 			snap_vbds
 	in
 	let snap_vdis = List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) snap_vbds_disk in
@@ -284,7 +284,7 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 
 	let vm_VBDs = Db.VM.get_VBDs ~__context ~self:vm in
 	(* Filter VBDs to ensure that we don't read empty CDROMs *)
-	let vbds_without_cd = List.filter (fun vbd -> Db.VBD.get_type ~__context ~self:vbd <> `CD) vm_VBDs in
+	let vbds_without_cd = List.filter (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk) vm_VBDs in
 	let vm_VDIs = List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) vbds_without_cd in
 	let vm_VDIs = List.filter (fun vdi -> List.mem vdi vdis_snap_of) vm_VDIs in
 	let vm_VIFs = Db.VM.get_VIFs ~__context ~self:vm in

--- a/ocaml/xapi/xapi_vm_snapshot.ml
+++ b/ocaml/xapi/xapi_vm_snapshot.ml
@@ -291,10 +291,6 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 	let vm_VGPUs = Db.VM.get_VGPUs ~__context ~self:vm in
 	let vm_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:vm in
 
-	let oldvdi_to_snapshots_map = List.map (fun vdi -> let snaps = Db.VDI.get_snapshots ~__context ~self:vdi in
-		(vdi, snaps)
-	) vm_disks_with_snapshot in
-
 	(* clone all the disks of the snapshot *)
 	Helpers.call_api_functions ~__context (fun rpc session_id ->
 
@@ -310,11 +306,24 @@ let update_vifs_vbds_and_vgpus ~__context ~snapshot ~vm =
 		TaskHelper.set_progress ~__context 0.5;
 
 		debug "Updating the snapshot_of fields for relevant VDIs";
-		let oldvdi_to_newvdi_map = List.map2 (fun oldvdi (_, newvdi, _) -> (oldvdi,newvdi)) snap_disks_snapshot_of cloned_disks in
-		List.iter (fun (oldvdi, snaps) ->
-			let newvdi = List.assoc oldvdi oldvdi_to_newvdi_map in
-			List.iter (fun s -> Db.VDI.set_snapshot_of ~__context ~self:s ~value:newvdi) snaps
-		) oldvdi_to_snapshots_map;
+		List.iter2
+			(fun snap_disk (_, cloned_disk, _) ->
+				(* For each snapshot disk which was just cloned:
+				 * 1) Find the value of snapshot_of
+				 * 2) Find all snapshots with the same snapshot_of
+				 * 3) Update each of these snapshots so that their snapshot_of points
+				 *    to the new cloned disk. *)
+				let open Db_filter_types in
+				let snapshot_of = Db.VDI.get_snapshot_of ~__context ~self:snap_disk in
+				let all_snaps_in_tree = Db.VDI.get_refs_where ~__context
+					~expr:(Eq (Field "snapshot_of", Literal (Ref.string_of snapshot_of)))
+				in
+				List.iter
+					(fun snapshot ->
+						Db.VDI.set_snapshot_of ~__context ~self:snapshot ~value:cloned_disk)
+					all_snaps_in_tree)
+			snap_disks
+			cloned_disks;
 
 		debug "Cloning the suspend VDI if needed";
 		let cloned_suspend_VDI =


### PR DESCRIPTION
Make sure that snapshot_of links are set correctly after
- Reverting a VM with multiple disks to a snapshot
- Reverting a VM to a snapshot after deleting one or more of the VM's disks
