### PR TITLE
CA-164736: Increase FD limit for xcp-rrdd to 4096

### DIFF
--- a/scripts/init.d-rrdd
+++ b/scripts/init.d-rrdd
@@ -24,6 +24,9 @@ PID_FILE="/var/run/${NAME}.pid"
 # lock file
 SUBSYS_FILE="/var/lock/subsys/${NAME}"
 
+# set max number of open fds
+ulimit -n 4096
+
 start() {
 	echo -n $"Starting ${FULL_NAME}: "
 


### PR DESCRIPTION
This component isn't using the select() system call on these fds so there is no
concern about the 1024 limit imposed by the kernel ABI.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
