### PR TITLE
CA-165130: Xapi to notify xcp-rrdd to update its role

### DIFF
--- a/ocaml/pool_role_shared.ml
+++ b/ocaml/pool_role_shared.ml
@@ -53,6 +53,12 @@ let get_role () =
 			r
 	)
 
+let update_role () =
+	Mutex.execute role_m (fun _ ->
+		let r = read_pool_role () in
+		role := Some r;
+	)
+
 let is_master () = get_role () = Master
 
 let is_slave () = match get_role () with

--- a/ocaml/rrdd/interface/rrdd_interface.ml
+++ b/ocaml/rrdd/interface/rrdd_interface.ml
@@ -36,6 +36,7 @@ external migrate_rrd : ?session_id:string -> remote_address:string ->
 	vm_uuid:string -> host_uuid:string -> unit -> unit = ""
 external send_host_rrd_to_master : unit -> unit = ""
 external backup_rrds : ?save_stats_locally:bool -> unit -> unit = ""
+external update_role : unit -> unit = ""
 
 external add_host_ds : ds_name:string -> unit = ""
 external forget_host_ds : ds_name:string -> unit = ""

--- a/ocaml/rrdd/rrdd_server.ml
+++ b/ocaml/rrdd/rrdd_server.ml
@@ -351,6 +351,9 @@ let send_host_rrd_to_master _ () =
 		archive_rrd ~save_stats_locally:false ~uuid:localhost_uuid ~rrd ()
 	| None -> ()
 
+let update_role _ () =
+	Pool_role_shared.update_role ()
+
 let add_ds ~rrdi ~ds_name =
 	let open Ds in
 	let ds = List.find (fun ds -> ds.ds_name = ds_name) rrdi.dss in

--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -211,6 +211,9 @@ let migrate_rrd ~__context ?remote_address ?session_id ~vm_uuid ~host_uuid () =
 		Rrdd.migrate_rrd ~remote_address ?session_id ~vm_uuid ~host_uuid
 	)
 
+let update_role () =
+	Rrdd.update_role ()
+
 module Deprecated = struct
 	let get_timescale ~__context =
 		let host = Helpers.get_localhost ~__context in

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -820,6 +820,7 @@ let server_init() =
     "Reading config file", [], (fun () -> Xapi_config.read_config !Xapi_globs.config_file);
     "Reading external global variables definition", [ Startup.NoExnRaising ], Xapi_globs.read_external_config;
     "XAPI SERVER STARTING", [], print_server_starting_message;
+    "Notify xcp-rrdd to update its role", [], Rrdd_proxy.update_role;
     "Parsing inventory file", [], Xapi_inventory.read_inventory;
     "Setting stunnel timeout", [], set_stunnel_timeout;
     "Initialising local database", [], init_local_database;


### PR DESCRIPTION
After a host joins to pool, the xapi restarts in slave mode. However,
the xcp-rrdd remains in master mode only.
This patch asks xapi to notify the xcp-rrdd to update its role after
pool-join.

Signed-off-by: Ravi Pandey ravi.pandey@citrix.com
