### PR TITLE
CA-165663: Xapi to notify rrdd to archive rrd data

### DIFF
--- a/ocaml/rrdd/interface/rrdd_interface.ml
+++ b/ocaml/rrdd/interface/rrdd_interface.ml
@@ -36,6 +36,7 @@ external migrate_rrd : ?session_id:string -> remote_address:string ->
 	vm_uuid:string -> host_uuid:string -> unit -> unit = ""
 external send_host_rrd_to_master : unit -> unit = ""
 external backup_rrds : ?save_stats_locally:bool -> unit -> unit = ""
+external archive_vm_rrd : vm_uuid:string -> unit -> unit = ""
 
 external add_host_ds : ds_name:string -> unit = ""
 external forget_host_ds : ds_name:string -> unit = ""

--- a/ocaml/rrdd/rrdd_main.ml
+++ b/ocaml/rrdd/rrdd_main.ml
@@ -449,9 +449,6 @@ let update_vbds doms =
 (*****************************************************)
 let lock = Mutex.create ()
 
-(** Rebooting VMs - lock out the sending back of the RRDs *)
-let rebooting_vms = ref StringSet.empty
-
 let previous_oldness = ref 0
 let previous_free_words = ref 0
 let previous_live_words = ref 0
@@ -583,8 +580,6 @@ let handle_exn log f default =
 let read_all_dom0_stats xc =
 	let domains = Xenctrl.domain_getinfolist xc 0 in
 	let timestamp = Unix.gettimeofday () in
-	let my_rebooting_vms =
-		StringSet.fold (fun uuid acc -> uuid::acc) !rebooting_vms [] in
 	let open Xenctrl.Domain_info in
 	let uuid_of_domain d =
 		Uuid.to_string (Uuid.uuid_of_int_array (d.handle)) in
@@ -613,17 +608,17 @@ let read_all_dom0_stats xc =
 	] in
 	let fake_stats = Rrdd_fake.get_fake_stats (List.map fst uuid_domids) in
 	let all_stats = Rrdd_fake.combine_stats real_stats fake_stats in
-	all_stats, uuid_domids, pifs, timestamp, my_rebooting_vms, my_paused_domain_uuids
+	all_stats, uuid_domids, pifs, timestamp, my_paused_domain_uuids
 
 let do_monitor xc =
 	Stats.time_this "monitor"
 		(fun _ ->
-			let dom0_stats, uuid_domids, pifs, timestamp, my_rebooting_vms, my_paused_vms =
+			let dom0_stats, uuid_domids, pifs, timestamp, my_paused_vms =
 				read_all_dom0_stats xc in
 			let plugins_stats = Rrdd_server.Plugin.read_stats () in
 			let stats = List.rev_append plugins_stats dom0_stats in
 			Rrdd_stats.print_snapshot ();
-			Rrdd_monitor.update_rrds timestamp stats uuid_domids pifs my_rebooting_vms my_paused_vms
+			Rrdd_monitor.update_rrds timestamp stats uuid_domids pifs my_paused_vms
 		)
 
 let monitor_loop () =

--- a/ocaml/rrdd/rrdd_monitor.ml
+++ b/ocaml/rrdd/rrdd_monitor.ml
@@ -46,11 +46,13 @@ let create_fresh_rrd use_min_max dss =
  * domain has gone and we stream the RRD to the master. We also have a
  * list of the currently rebooting VMs to ensure we don't accidentally
  * archive the RRD. *)
-let update_rrds timestamp dss (uuid_domids : (string * int) list) pifs rebooting_vms paused_vms =
+let update_rrds timestamp dss (uuid_domids : (string * int) list) pifs paused_vms =
 	(* Here we do the synchronising between the dom0 view of the world
-		 and our Hashtbl. By the end of this execute block, the Hashtbl
-		 correctly represents the world *)
-	let to_send_back = Mutex.execute mutex (fun _ ->
+	 * and our Hashtbl. RRD's of new created domains will be added to
+	 * the Hashtbl. RRD's of disappeared domains won't be removed until
+	 * archive_vm_rrd is called by xapi.
+	 *)
+	Mutex.execute mutex (fun _ ->
 		let out_of_date, by_how_much =
 			match !host_rrd with
 			| None -> false, 0.
@@ -58,16 +60,6 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) pifs rebooting
 		in
 		if out_of_date then
 			error "Clock just went backwards by %.0f seconds: RRD data may now be unreliable" by_how_much;
-		let registered = Hashtbl.fold_keys vm_rrds in
-		let gone_vms = List.filter (fun vm -> not (List.mem_assoc vm uuid_domids)) registered in
-		let to_send_back = List.map (fun uuid -> uuid, Hashtbl.find vm_rrds uuid) gone_vms in
-		(* Don't send back rebooting VMs! *)
-		let to_send_back = List.filter (fun (uuid, _) ->
-			let rebooting = (List.exists (fun uuid' -> uuid = uuid') rebooting_vms) in
-			if rebooting then debug "Ignoring disappeared VM which is rebooting";
-			not rebooting
-		) to_send_back in
-		List.iter (fun (uuid, _) -> Hashtbl.remove vm_rrds uuid) to_send_back;
 		let do_vm (vm_uuid, domid) =
 			try
 				let dss = List.filter_map (fun (ty, ds) -> match ty with | VM x -> if x = vm_uuid then Some ds else None | _ -> None) dss in
@@ -172,8 +164,5 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) pifs rebooting
 		if (not (StringSet.is_empty !dirty_pifs)) || (not (StringSet.is_empty !dirty_memory)) || (!dirty_host_memory) then
 			Condition.broadcast condition;
 		*)
-		to_send_back
 	)
-	in List.iter (fun (uuid, rrdi) ->
-		debug "Sending back RRD for VM uuid=%s" uuid;
-		archive_rrd ~uuid ~rrd:rrdi.rrd ()) to_send_back
+

--- a/ocaml/rrdd/rrdd_server.ml
+++ b/ocaml/rrdd/rrdd_server.ml
@@ -351,6 +351,18 @@ let send_host_rrd_to_master _ () =
 		archive_rrd ~save_stats_locally:false ~uuid:localhost_uuid ~rrd ()
 	| None -> ()
 
+(* Called on VM shutdown/suspend to send the VM's RRD to the pool master
+ * for archiving.  The memory copy will also be cleaned.
+ *)
+let archive_vm_rrd _ ~(vm_uuid : string) () : unit =
+	debug "Archiving VM %s RRD to master" vm_uuid;
+	let rrd = Mutex.execute mutex (fun () ->
+		let rrd = (Hashtbl.find vm_rrds vm_uuid).rrd in
+		Hashtbl.remove vm_rrds vm_uuid;
+		rrd
+	) in
+	archive_rrd ~uuid:vm_uuid ~rrd ()
+
 let add_ds ~rrdi ~ds_name =
 	let open Ds in
 	let ds = List.find (fun ds -> ds.ds_name = ds_name) rrdi.dss in

--- a/ocaml/xapi/rrdd_proxy.ml
+++ b/ocaml/xapi/rrdd_proxy.ml
@@ -50,7 +50,7 @@ let fail_req_with (s : Unix.file_descr) msg (http_err : unit -> string list) =
  * the master. The exact logic can be seen under "The logic." below.
  *)
 let get_vm_rrd_forwarder (req : Http.Request.t) (s : Unix.file_descr) _ =
-	debug "put_rrd_forwarder: start";
+	debug "get_vm_rrd_forwarder: start";
 	let query = req.Http.Request.query in
 	req.Http.Request.close <- true;
 	let vm_uuid = List.assoc "uuid" query in
@@ -210,6 +210,10 @@ let migrate_rrd ~__context ?remote_address ?session_id ~vm_uuid ~host_uuid () =
 	log_and_ignore_exn (
 		Rrdd.migrate_rrd ~remote_address ?session_id ~vm_uuid ~host_uuid
 	)
+
+(* Send archive command to RRDD in the same host *)
+let archive_vm_rrd ~__context ~(vm_uuid : string) : unit =
+	log_and_ignore_exn (Rrdd.archive_vm_rrd ~vm_uuid)
 
 module Deprecated = struct
 	let get_timescale ~__context =

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -959,6 +959,7 @@ let update_vm ~__context id =
 							if power_state = `Suspended || power_state = `Halted then begin
 								Xapi_network.detach_for_vm ~__context ~host:localhost ~vm:self;
 								Storage_access.reset ~__context ~vm:self;
+								Rrdd_proxy.archive_vm_rrd ~__context ~vm_uuid:id
 							end;
 							if power_state = `Halted
 							then Xenopsd_metadata.delete ~__context id;


### PR DESCRIPTION
Since rrdd could not distinguish rebooting VMs from halted/suspended
VMs, rrdd will archive the rrd data and remove it from memory.  When
the VM finishing rebooting the pool master would not push the rrd
data to rrdd, that makes the loss of history rrd data.

Now xapi will tell rrdd to archive the rrd data (and remove it from
memory) when a domain has gone away.  Rrdd does not need to detect
rebooting VMs now.

Signed-off-by: Kaifeng Zhu kaifeng.zhu@citrix.com
