### PR TITLE
[Caboodle/HFX-1385] CA-163866: VM hard_reboot must cancel clean_reboot on slaves

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1379,7 +1379,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				(fun () ->
 				  List.iter (fun (task,op) ->
 				    if op = `clean_shutdown then
-				      try Local.Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
+				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
 
 					(* If VM is actually suspended and we ask to hard_shutdown, we need to
 					   forward to any host that can see the VDIs *)
@@ -1427,7 +1427,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				(fun () ->
 				  List.iter (fun (task,op) ->
 				    if op = `clean_reboot then
-				      try Local.Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
+				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
 
 
 					with_vbds_marked ~__context ~vm ~doc:"VM.hard_reboot" ~op:`attach


### PR DESCRIPTION
This patch is a fix for SCTX-2017.
Additionally, It also cancels clean_shutdown on slaves on applying hard_shutdown.

Signed-off-by: Sharad Yadav sharad.yadav@citrix.com
