### PR TITLE
[Caboodle/HFX-1354] Fix for CA-151670 and CA-93557

### DIFF
--- a/ocaml/xapi/helpers.ml
+++ b/ocaml/xapi/helpers.ml
@@ -898,25 +898,56 @@ let is_network_properly_shared ~__context ~self =
 		warn "Network %s not shared properly: Not all hosts have PIFs" (Ref.string_of self);
 	properly_shared
 
-let vm_assert_agile ~__context ~self =
+module SRSet = Set.Make(struct type t = API.ref_SR let compare = compare end)
+module NetworkSet = Set.Make(struct type t = API.ref_network let compare = compare end)
+
+let empty_cache = (SRSet.empty, NetworkSet.empty)
+
+let caching_vm_t_assert_agile ~__context (ok_srs, ok_networks) self vm_t =
+	(* Any kind of vGPU means that the VM is not agile. *)
 	if Db.VM.get_VGPUs ~__context ~self <> [] then
 		raise (Api_errors.Server_error
 			(Api_errors.vm_has_vgpu, [Ref.string_of self]));
-  (* All referenced VDIs should be in shared SRs *)
-  List.iter (fun vbd ->
-	       if not(Db.VBD.get_empty ~__context ~self:vbd) then begin
-		 let vdi = Db.VBD.get_VDI ~__context ~self:vbd in
-		 let sr = Db.VDI.get_SR ~__context ~self:vdi in
-		 if not(is_sr_properly_shared ~__context ~self:sr)
-		 then raise (Api_errors.Server_error(Api_errors.ha_constraint_violation_sr_not_shared, [ Ref.string_of sr ]))
-	       end)
-    (Db.VM.get_VBDs ~__context ~self);
-  (* All referenced VIFs should be on shared networks *)
-  List.iter (fun vif ->
-	       let network = Db.VIF.get_network ~__context ~self:vif in
-	       if not(is_network_properly_shared ~__context ~self:network)
-	       then raise (Api_errors.Server_error(Api_errors.ha_constraint_violation_network_not_shared, [ Ref.string_of network ])))
-    (Db.VM.get_VIFs ~__context ~self)
+	(* All referenced VDIs should be in shared SRs *)
+	let check_vbd ok_srs vbd =
+		if Db.VBD.get_empty ~__context ~self:vbd
+		then ok_srs
+		else
+			let vdi = Db.VBD.get_VDI ~__context ~self:vbd in
+			let sr = Db.VDI.get_SR ~__context ~self:vdi in
+			if SRSet.mem sr ok_srs
+			then ok_srs
+			else
+				if not (is_sr_properly_shared ~__context ~self:sr)
+				then raise (Api_errors.Server_error(Api_errors.ha_constraint_violation_sr_not_shared, [Ref.string_of sr]))
+				else SRSet.add sr ok_srs in
+	(* All referenced VIFs should be on shared networks *)
+	let check_vif ok_networks vif =
+		let network = Db.VIF.get_network ~__context ~self:vif in
+		if NetworkSet.mem network ok_networks
+		then ok_networks
+		else
+			if not (is_network_properly_shared ~__context ~self:network)
+			then raise (Api_errors.Server_error(Api_errors.ha_constraint_violation_network_not_shared, [Ref.string_of network]))
+			else NetworkSet.add network ok_networks in
+	let ok_srs = List.fold_left check_vbd ok_srs vm_t.API.vM_VBDs in
+	let ok_networks = List.fold_left check_vif ok_networks vm_t.API.vM_VIFs in
+	(ok_srs, ok_networks)
+
+let vm_assert_agile ~__context ~self =
+	let vm_t = Db.VM.get_record ~__context ~self in
+	let _ = caching_vm_t_assert_agile ~__context empty_cache self vm_t in
+	()
+
+let partition_vm_ps_by_agile ~__context vm_ps =
+	let distinguish_vm (agile_vm_ps, not_agile_vm_ps, cache) ((vm, vm_t) as vm_p) =
+		try
+			let cache = caching_vm_t_assert_agile ~__context cache vm vm_t in
+			(vm_p :: agile_vm_ps, not_agile_vm_ps, cache)
+		with _ ->
+		  (agile_vm_ps, vm_p :: not_agile_vm_ps, cache) in
+	let agile_vm_ps, not_agile_vm_ps, _ = List.fold_left distinguish_vm ([], [], empty_cache) vm_ps in
+	(List.rev agile_vm_ps, List.rev not_agile_vm_ps)
 
 (* Select an item from a list with a probability proportional to the items weight / total weight of all items *)
 let weighted_random_choice weighted_items (* list of (item, integer) weight *) =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -900,7 +900,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					let host = Xapi_vm_helpers.choose_host_for_vm ~__context ~vm ~snapshot in
 					(* HA overcommit protection: we can either perform 'n' HA plans by including this in
 					   the 'choose_host_for_vm' function or we can be cheapskates by doing it here: *)
-					Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ();
+					if snapshot.API.vM_ha_restart_priority = Constants.ha_restart
+					then
+						Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm
+					else
+						Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ();
 					allocate_vm_to_host ~__context ~vm ~host ~snapshot ?host_op ();
 					host) in
 			finally
@@ -920,7 +924,11 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					(* NB in the case of migrate although we are about to increase free memory on the sending host
 					   we ignore this because if a failure happens while a VM is in-flight it will still be considered
 					   on both hosts, potentially breaking the failover plan. *)
-					Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ();
+					if snapshot.API.vM_ha_restart_priority = Constants.ha_restart
+					then
+						Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm
+					else
+						Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ();
 					allocate_vm_to_host ~__context ~vm ~host ~snapshot ?host_op ());
 			finally f
 				(fun () ->

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -884,7 +884,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			| None -> ()
 
 		let check_vm_preserves_ha_plan ~__context ~vm ~snapshot ~host =
-			if snapshot.API.vM_ha_restart_priority = Constants.ha_restart
+			if true
+				&& (snapshot.API.vM_ha_restart_priority = Constants.ha_restart)
+				&& (not snapshot.API.vM_ha_always_run)
 			then
 				Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm
 			else

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -883,6 +883,13 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 				  Early_wakeup.broadcast (Datamodel._host, Ref.string_of host);
 			| None -> ()
 
+		let check_vm_preserves_ha_plan ~__context ~vm ~snapshot ~host =
+			if snapshot.API.vM_ha_restart_priority = Constants.ha_restart
+			then
+				Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm
+			else
+				Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ()
+
 		(* README: Note on locking -- forward_to_suitable_host and reserve_memory_for_vm are only
 		   called in a context where the current_operations field for the VM object contains the
 		   operation we're considering. Thus the global_lock in this context is _not_ used to cover
@@ -900,11 +907,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					let host = Xapi_vm_helpers.choose_host_for_vm ~__context ~vm ~snapshot in
 					(* HA overcommit protection: we can either perform 'n' HA plans by including this in
 					   the 'choose_host_for_vm' function or we can be cheapskates by doing it here: *)
-					if snapshot.API.vM_ha_restart_priority = Constants.ha_restart
-					then
-						Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm
-					else
-						Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ();
+					check_vm_preserves_ha_plan ~__context ~vm ~snapshot ~host;
 					allocate_vm_to_host ~__context ~vm ~host ~snapshot ?host_op ();
 					host) in
 			finally
@@ -924,11 +927,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 					(* NB in the case of migrate although we are about to increase free memory on the sending host
 					   we ignore this because if a failure happens while a VM is in-flight it will still be considered
 					   on both hosts, potentially breaking the failover plan. *)
-					if snapshot.API.vM_ha_restart_priority = Constants.ha_restart
-					then
-						Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm
-					else
-						Xapi_ha_vm_failover.assert_vm_placement_preserves_ha_plan ~__context ~arriving:[host, (vm, snapshot)] ();
+					check_vm_preserves_ha_plan ~__context ~vm ~snapshot ~host;
 					allocate_vm_to_host ~__context ~vm ~host ~snapshot ?host_op ());
 			finally f
 				(fun () ->

--- a/ocaml/xapi/xapi_ha_vm_failover.ml
+++ b/ocaml/xapi/xapi_ha_vm_failover.ml
@@ -171,8 +171,7 @@ let compute_restart_plan ~__context ~all_protected_vms ~live_set ?(change=no_con
 	(* Any deterministic ordering is fine here: *)
 	let vms_to_ensure_running = List.sort (fun (_, a) (_, b) -> compare a.API.vM_uuid b.API.vM_uuid) vms_to_ensure_running in
 
-	let agile_vms, not_agile_vms = List.partition (fun (vm,_) -> try Helpers.vm_assert_agile ~__context ~self:vm; true with _ -> false)
-		vms_to_ensure_running in
+	let agile_vms, not_agile_vms = Helpers.partition_vm_ps_by_agile ~__context vms_to_ensure_running in
 
 	(* If a VM is marked as resident on a live_host then it will already be accounted for in the host's current free memory. *)
 	let vm_accounted_to_host vm =

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -323,10 +323,7 @@ let suspend ~__context ~vm =
 
 let resume ~__context ~vm ~start_paused ~force = 
 	if Db.VM.get_ha_restart_priority ~__context ~self:vm = Constants.ha_restart
-	then begin
-		Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm;
-		Db.VM.set_ha_always_run ~__context ~self:vm ~value:true
-	end;
+	then Db.VM.set_ha_always_run ~__context ~self:vm ~value:true;
 
 	let host = Helpers.get_localhost ~__context in
 	if not force then Cpuid_helpers.assert_vm_is_compatible ~__context ~vm ~host ();

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -191,10 +191,8 @@ let start ~__context ~vm ~start_paused ~force =
 	Vgpuops.create_vgpus ~__context (vm, vmr) (Helpers.will_boot_hvm ~__context ~self:vm);
 
 	if vmr.API.vM_ha_restart_priority = Constants.ha_restart
-	then begin
-		Xapi_ha_vm_failover.assert_new_vm_preserves_ha_plan ~__context vm;
-		Db.VM.set_ha_always_run ~__context ~self:vm ~value:true
-	end;
+	then Db.VM.set_ha_always_run ~__context ~self:vm ~value:true;
+
 	(* If the VM has any vGPUs, gpumon must remain stopped until the
 	 * VM has started. *)
 	match vmr.API.vM_VGPUs with


### PR DESCRIPTION
This PR acknowledge 2 fixes:
1) CA-151670: Don't double count HA-protected VMs when restarting them 
When attempting to restart HA-protected VMs after an HA failure, they
should be not treated as new VMs to add to the HA plan, since HA will
already be taking them into account.

2) CA-93557: Poor performance for VMs in 'Restart' vs 'Restart if possible'
It was a side-effect of the fix for CA-57613.
This pull-request also include an optimization made for SCTX-1033.

Creating a single pull request as the fix for CA-151670 is dependent on CA-93557.
