### PR TITLE
SCTX-2115 CA-182595: Force lifecycle operations must cancel clean ones

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -190,11 +190,11 @@ let remote_rpc_retry context hostname (task_opt: API.ref_task option) xml =
 	XML_protocol.rpc ~srcstr:"xapi" ~dststr:"dst_xapi" ~transport ~http xml
 
 let call_slave_with_session remote_rpc_fn __context host (task_opt: API.ref_task option) f =
-	let session_id = Xapi_session.login_no_password ~__context ~uname:None ~host ~pool:true ~is_local_superuser:true ~subject:(Ref.null) ~auth_user_sid:"" ~auth_user_name:"" ~rbac_permissions:[] in
 	let hostname = Db.Host.get_address ~__context ~self:host in
+	let session_id = Xapi_session.login_no_password ~__context ~uname:None ~host ~pool:true ~is_local_superuser:true ~subject:(Ref.null) ~auth_user_sid:"" ~auth_user_name:"" ~rbac_permissions:[] in
 	Pervasiveext.finally
 		(fun ()->f session_id (remote_rpc_fn __context hostname task_opt))
-		(fun ()->Server_helpers.exec_with_new_task ~session_id "local logout in message forwarder" (fun __context -> Xapi_session.logout ~__context))
+		(fun () -> Xapi_session.destroy_db_session ~__context ~self:session_id)
 
 let call_slave_with_local_session remote_rpc_fn __context host (task_opt: API.ref_task option) f =
 	let hostname = Db.Host.get_address ~__context ~self:host in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -841,10 +841,9 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 		(* Read resisdent-on field from vm to determine who to forward to  *)
 		let forward_vm_op ~local_fn ~__context ~vm op =
-			let state = Db.VM.get_power_state ~__context ~self:vm in
-			match state with
-			| `Running | `Paused ->  do_op_on ~local_fn ~__context ~host:(Db.VM.get_resident_on ~__context ~self:vm) op
-			| _ -> raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [Ref.string_of vm; "running"; Record_util.power_to_string state]))
+			Xapi_vm_lifecycle.assert_power_state_in ~__context ~self:vm
+				~allowed:[`Running; `Paused];
+			do_op_on ~local_fn ~__context ~host:(Db.VM.get_resident_on ~__context ~self:vm) op
 
 		(* Notes on memory checking/reservation logic:
 		   When computing the hosts free memory we consider all VMs resident_on (ie running
@@ -3214,11 +3213,8 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let vbds = Db.VDI.get_VBDs ~__context ~self in
 			List.iter (fun vbd ->
 				let vm = Db.VBD.get_VM ~__context ~self:vbd in
-				let state = Db.VM.get_power_state ~__context ~self:vm in
-				match state with
-				| `Halted -> ()
-				| _ -> raise (Api_errors.Server_error(Api_errors.vm_bad_power_state,
-				  [Ref.string_of vm; "halted"; Record_util.power_to_string state]))) vbds
+				Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vm ~expected:`Halted
+			) vbds
 
 		let set_on_boot ~__context ~self ~value =
 			ensure_vdi_not_on_running_vm ~__context ~self;

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1385,9 +1385,19 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let local_fn = Local.VM.hard_shutdown ~vm in
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_shutdown" ~op:`hard_shutdown
 				(fun () ->
-				  List.iter (fun (task,op) ->
-				    if List.mem op [ `clean_shutdown; `clean_reboot; `hard_reboot ] then
-				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
+					(* Before doing the shutdown we might need to cancel existing operations *)
+					List.iter (fun (task,op) ->
+						if List.mem op [ `clean_shutdown; `clean_reboot; `hard_reboot ] then (
+							(* At the end of the cancellation, if the VM is on a slave then the task doing
+							 * the cancellation will be marked complete (successful).  This would be premature
+							 * for the current task since it still has work to do: first possibly some more
+							 * cancellations, then definitely the VM hard_shutdown. Therefore we must spawn
+							 * a new task to do the cancellation. (But no need to go via API call.) *)
+							Server_helpers.exec_with_subtask ~__context
+								("Cancelling VM." ^ (Record_util.vm_operation_to_string op) ^ " for VM.hard_shutdown")
+								(fun ~__context -> try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ())
+						)
+					) (Db.VM.get_current_operations ~__context ~self:vm);
 
 					(* If VM is actually suspended and we ask to hard_shutdown, we need to
 					   forward to any host that can see the VDIs *)
@@ -1433,11 +1443,15 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let local_fn = Local.VM.hard_reboot ~vm in
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_reboot" ~op:`hard_reboot
 				(fun () ->
-				  List.iter (fun (task,op) ->
-				    if List.mem op [ `clean_shutdown; `clean_reboot ] then
-				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
-
-
+					(* Before doing the reboot we might need to cancel existing operations *)
+					List.iter (fun (task,op) ->
+						if List.mem op [ `clean_shutdown; `clean_reboot ] then (
+							(* We must do the cancelling in a subtask: see hard_shutdown comment for reason. *)
+							Server_helpers.exec_with_subtask ~__context
+								("Cancelling VM." ^ (Record_util.vm_operation_to_string op) ^ " for VM.hard_reboot")
+								(fun ~__context -> try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ())
+						)
+					) (Db.VM.get_current_operations ~__context ~self:vm);
 					with_vbds_marked ~__context ~vm ~doc:"VM.hard_reboot" ~op:`attach
 						(fun vbds ->
 							with_vifs_marked ~__context ~vm ~doc:"VM.hard_reboot" ~op:`attach

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1386,7 +1386,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_shutdown" ~op:`hard_shutdown
 				(fun () ->
 				  List.iter (fun (task,op) ->
-				    if op = `clean_shutdown then
+				    if List.mem op [ `clean_shutdown; `clean_reboot; `hard_reboot ] then
 				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
 
 					(* If VM is actually suspended and we ask to hard_shutdown, we need to
@@ -1434,7 +1434,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			with_vm_operation ~__context ~self:vm ~doc:"VM.hard_reboot" ~op:`hard_reboot
 				(fun () ->
 				  List.iter (fun (task,op) ->
-				    if op = `clean_reboot then
+				    if List.mem op [ `clean_shutdown; `clean_reboot ] then
 				      try Task.cancel ~__context ~task:(Ref.of_string task) with _ -> ()) (Db.VM.get_current_operations ~__context ~self:vm);
 
 

--- a/ocaml/xapi/mtc.ml
+++ b/ocaml/xapi/mtc.ml
@@ -273,12 +273,6 @@ let update_vm_state_if_necessary ~__context ~vm =
       raise e
   end
 
-(* Raises an exception if the destination VM is not in the expected power state:  halted *)
-let verify_dest_vm_power_state ~__context ~vm =
-  let actual = Db.VM.get_power_state ~__context ~self:vm in
-  if actual != `Halted then
-    raise(Api_errors.Server_error(Api_errors.vm_bad_power_state, [Ref.string_of vm; "halted"; (Record_util.power_to_string actual)]))
-
 (* Returns true if VDI is accessed by an MTC-protected VM *)
 let is_vdi_accessed_by_protected_VM ~__context ~vdi =
 

--- a/ocaml/xapi/xapi_vbd.ml
+++ b/ocaml/xapi/xapi_vbd.ml
@@ -33,9 +33,7 @@ let assert_attachable ~__context ~self : unit =
 
 let set_mode ~__context ~self ~value =
 	let vm = Db.VBD.get_VM ~__context ~self in
-	let power_state = Db.VM.get_power_state ~__context ~self:vm in
-	if power_state <> `Halted
-	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [Ref.string_of vm; Record_util.power_to_string `Halted; Record_util.power_to_string power_state]));
+	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vm ~expected:`Halted;
 	Db.VBD.set_mode ~__context ~self ~value
 
 let plug ~__context ~self =

--- a/ocaml/xapi/xapi_vgpu.ml
+++ b/ocaml/xapi/xapi_vgpu.ml
@@ -26,10 +26,7 @@ let create ~__context  ~vM ~gPU_group ~device ~other_config ~_type =
 	let uuid = Uuid.to_string (Uuid.make_uuid ()) in
 	if not (Pool_features.is_enabled ~__context Features.GPU) then
 		raise (Api_errors.Server_error (Api_errors.feature_restricted, []));
-	let vm_power_state = Db.VM.get_power_state ~__context ~self:vM in
-	if (vm_power_state <> `Halted) then
-		raise (Api_errors.Server_error (Api_errors.vm_bad_power_state,
-			Ref.string_of vM :: List.map Record_util.power_to_string [`Halted; vm_power_state]));
+	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self:vM ~expected:`Halted;
 	if not(valid_device device) then
 		raise (Api_errors.Server_error (Api_errors.invalid_device, [device]));
 

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -155,15 +155,6 @@ let set_memory_limits ~__context ~self
 	Vm_memory_constraints.set ~__context ~vm_ref:self ~constraints;
 	update_memory_overhead ~__context ~vm:self
 
-(* CA-12940: sanity check to make sure this never happens again *)
-let assert_power_state_is ~__context ~vm ~expected =
-	let actual = Db.VM.get_power_state ~__context ~self:vm in
-	if actual <> expected
-	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
-								Ref.string_of vm;
-								Record_util.power_to_string expected;
-								Record_util.power_to_string actual ]))
-
 (* If HA is enabled on the Pool and the VM is marked as always_run then block the action *)
 let assert_not_ha_protected ~__context ~vm =
 	let pool = Helpers.get_pool ~__context in

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -642,9 +642,7 @@ let set_HVM_shadow_multiplier ~__context ~self ~value =
 
 (** Sets the HVM shadow multiplier for a {b Running} VM. Runs on the slave. *)
 let set_shadow_multiplier_live ~__context ~self ~multiplier =
-	let power_state = Db.VM.get_power_state ~__context ~self in
-	if power_state <> `Running
-	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [Ref.string_of self; "running"; (Record_util.power_to_string power_state)]));
+	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Running;
 
 	validate_HVM_shadow_multiplier multiplier;
 
@@ -791,10 +789,7 @@ let recover ~__context ~self ~session_to ~force =
 	ignore (Xapi_dr.recover_vms ~__context ~vms:[self] ~session_to ~force)
 
 let set_suspend_VDI ~__context ~self ~value =
-	let vm_state =  Db.VM.get_power_state ~__context ~self in
-	if vm_state <> `Suspended then
-		raise (Api_errors.Server_error(Api_errors.vm_bad_power_state,
-			[Ref.string_of self; "suspended"; Record_util.power_to_string vm_state]));
+	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:`Suspended;
 	let src_vdi = Db.VM.get_suspend_VDI ~__context ~self in
 	let dst_vdi = value in
 	if src_vdi <> dst_vdi then

--- a/ocaml/xapi/xapi_vm.mli
+++ b/ocaml/xapi/xapi_vm.mli
@@ -63,17 +63,6 @@ val set_memory_limits :
   self:[ `VM ] Ref.t ->
   static_min:Int64.t ->
   static_max:Int64.t -> dynamic_min:Int64.t -> dynamic_max:Int64.t -> unit
-val assert_power_state_is :
-  __context:Context.t ->
-  vm:[ `VM ] Ref.t ->
-  expected:[< `Halted
-            | `Migrating
-            | `Paused
-            | `Running
-            | `ShuttingDown
-            | `Suspended
-            > `Halted `Paused `Running `Suspended ] ->
-  unit
 val assert_not_ha_protected : __context:Context.t -> vm:[ `VM ] Ref.t -> unit
 val pause : __context:Context.t -> vm:API.ref_VM -> unit
 val unpause : __context:Context.t -> vm:API.ref_VM -> unit

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -479,3 +479,13 @@ let cancel_tasks ~__context ~self ~all_tasks_in_db ~task_ids =
 let get_operation_error ~__context ~self ~op=
 	let all, gm, clone_suspended_vm_enabled, vdis_reset_and_caching = get_info ~__context ~self in
 	check_operation_error __context all gm self clone_suspended_vm_enabled vdis_reset_and_caching op
+
+
+type power_state = [ `Halted | `Paused | `Running | `Suspended ]
+let assert_power_state_is ~__context ~self ~(expected:power_state) =
+	let actual = Db.VM.get_power_state ~__context ~self in
+	if actual <> expected
+	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
+								Ref.string_of self;
+								Record_util.power_to_string expected;
+								Record_util.power_to_string actual ]))

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -481,13 +481,12 @@ let get_operation_error ~__context ~self ~op=
 	check_operation_error __context all gm self clone_suspended_vm_enabled vdis_reset_and_caching op
 
 
-type power_state = [ `Halted | `Paused | `Running | `Suspended ]
-let assert_power_state_in ~__context ~self ~(allowed:power_state list) =
+let assert_power_state_in ~__context ~self ~allowed =
 	let actual = Db.VM.get_power_state ~__context ~self in
 	if not (List.mem actual allowed)
 	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
-								Ref.string_of self;
-                String.concat ";" (List.map Record_util.power_to_string allowed);
-								Record_util.power_to_string actual ]))
+		Ref.string_of self;
+		String.concat ";" (List.map Record_util.power_to_string allowed);
+		Record_util.power_to_string actual ]))
 
 let assert_power_state_is ~expected = assert_power_state_in ~allowed:[expected]

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -482,10 +482,12 @@ let get_operation_error ~__context ~self ~op=
 
 
 type power_state = [ `Halted | `Paused | `Running | `Suspended ]
-let assert_power_state_is ~__context ~self ~(expected:power_state) =
+let assert_power_state_in ~__context ~self ~(allowed:power_state list) =
 	let actual = Db.VM.get_power_state ~__context ~self in
-	if actual <> expected
+	if not (List.mem actual allowed)
 	then raise (Api_errors.Server_error(Api_errors.vm_bad_power_state, [
 								Ref.string_of self;
-								Record_util.power_to_string expected;
+                String.concat ";" (List.map Record_util.power_to_string allowed);
 								Record_util.power_to_string actual ]))
+
+let assert_power_state_is ~expected = assert_power_state_in ~allowed:[expected]

--- a/ocaml/xapi/xapi_vm_migrate.ml
+++ b/ocaml/xapi/xapi_vm_migrate.ml
@@ -764,7 +764,7 @@ let handler req fd _ =
 
 			let dbg = Context.string_of_task __context in
 			Xapi_network.with_networks_attached_for_vm ~__context ~vm (fun () ->
-				Xapi_xenops.transform_xenops_exn ~__context (fun () ->
+				Xapi_xenops.transform_xenops_exn ~__context ~vm (fun () ->
 					debug "Sending VM %s configuration to xenopsd" (Ref.string_of vm);
 					let id = Xapi_xenops.Xenopsd_metadata.push ~__context ~upgrade:true ~self:vm in
 					info "xenops: VM.receive_memory %s" id;

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1693,7 +1693,7 @@ let success_task f dbg id =
 
 (* Catch any uncaught xenops exceptions and transform into the most relevant XenAPI error.
    We do not want a XenAPI client to see a raw xenopsd error. *)
-let transform_xenops_exn ~__context f =
+let transform_xenops_exn ~__context ~vm f =
 	let reraise code params =
 		error "Re-raising as %s [ %s ]" code (String.concat "; " params);
 		raise (Api_errors.Server_error(code, params)) in
@@ -1711,9 +1711,9 @@ let transform_xenops_exn ~__context f =
 		| Domain_not_built -> internal "domain has not been built"
 		| Invalid_vcpus n -> internal "the maximum number of vcpus configured for this VM is currently: %d" n
 		| Bad_power_state(found, expected) ->
-			let f x = x |> (fun x -> Some x) |> xenapi_of_xenops_power_state |> Record_util.power_state_to_string in
+			let f x = xenapi_of_xenops_power_state (Some x) |> Record_util.power_state_to_string in
 			let found = f found and expected = f expected in
-			reraise Api_errors.vm_bad_power_state [ expected; found ]
+			reraise Api_errors.vm_bad_power_state [ Ref.string_of vm; expected; found ]
 		| Failed_to_acknowledge_shutdown_request ->
 			reraise Api_errors.vm_failed_shutdown_ack []
 		| Failed_to_shutdown(id, timeout) ->
@@ -1812,7 +1812,7 @@ let sync __context x =
 	x |> wait_for_task dbg |> success_task (update_debug_info __context) dbg
 
 let pause ~__context ~self =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.pause %s" id;
@@ -1823,7 +1823,7 @@ let pause ~__context ~self =
 		)
 
 let unpause ~__context ~self =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.unpause %s" id;
@@ -1834,7 +1834,7 @@ let unpause ~__context ~self =
 		)
 
 let set_xenstore_data ~__context ~self xsdata =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_xenstore_data %s" id;
@@ -1844,7 +1844,7 @@ let set_xenstore_data ~__context ~self xsdata =
 		)
 
 let set_vcpus ~__context ~self n =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_vcpus %s" id;
@@ -1869,7 +1869,7 @@ let set_vcpus ~__context ~self n =
 		)
 
 let set_shadow_multiplier ~__context ~self target =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_shadow_multiplier %s" id;
@@ -1888,7 +1888,7 @@ let set_shadow_multiplier ~__context ~self target =
 		)
 
 let set_memory_dynamic_range ~__context ~self min max =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			debug "xenops: VM.set_memory_dynamic_range %s" id;
@@ -1899,7 +1899,7 @@ let set_memory_dynamic_range ~__context ~self min max =
 
 let start ~__context ~self paused =
 	let dbg = Context.string_of_task __context in
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			(* For all devices which we want xenopsd to manage, set currently_attached = true
 			   so the metadata is pushed. *)
@@ -1944,7 +1944,7 @@ let start ~__context ~self paused =
 	Xapi_vm_lifecycle.assert_power_state_is ~__context ~self ~expected:(if paused then `Paused else `Running)
 
 let start ~__context ~self paused =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			try
 				start ~__context ~self paused
@@ -1958,7 +1958,7 @@ let start ~__context ~self paused =
 		)
 
 let reboot ~__context ~self timeout =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			assert_resident_on ~__context ~self;
 			let id = id_of_vm ~__context ~self in
@@ -1972,7 +1972,7 @@ let reboot ~__context ~self timeout =
 		)
 
 let shutdown ~__context ~self timeout =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			assert_resident_on ~__context ~self;
 			let id = id_of_vm ~__context ~self in
@@ -1991,7 +1991,7 @@ let shutdown ~__context ~self timeout =
 		)
 
 let suspend ~__context ~self =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			assert_resident_on ~__context ~self;
 			let id = id_of_vm ~__context ~self in
@@ -2036,7 +2036,7 @@ let suspend ~__context ~self =
 
 let resume ~__context ~self ~start_paused ~force =
 	let dbg = Context.string_of_task __context in
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let vdi = Db.VM.get_suspend_VDI ~__context ~self in
 			let disk = disk_of_vdi ~__context ~self:vdi |> Opt.unbox in
@@ -2075,7 +2075,7 @@ let resume ~__context ~self ~start_paused ~force =
 		)
 
 let s3suspend ~__context ~self =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			let dbg = Context.string_of_task __context in
@@ -2085,7 +2085,7 @@ let s3suspend ~__context ~self =
 		)
 
 let s3resume ~__context ~self =
-	transform_xenops_exn ~__context
+	transform_xenops_exn ~__context ~vm:self
 		(fun () ->
 			let id = id_of_vm ~__context ~self in
 			let dbg = Context.string_of_task __context in
@@ -2106,9 +2106,9 @@ let md_of_vbd ~__context ~self =
 	MD.of_vbd ~__context ~vm:(Db.VM.get_record ~__context ~self:vm) ~vbd:(Db.VBD.get_record ~__context ~self)
 
 let vbd_plug ~__context ~self =
-	transform_xenops_exn ~__context
+	let vm = Db.VBD.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
-			let vm = Db.VBD.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;
 			Events_from_xapi.wait ~__context ~self:vm;
 			let vbd = md_of_vbd ~__context ~self in
@@ -2128,9 +2128,9 @@ let vbd_plug ~__context ~self =
 		)
 
 let vbd_unplug ~__context ~self force =
-	transform_xenops_exn ~__context
+	let vm = Db.VBD.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
-			let vm = Db.VBD.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;
 			let vbd = md_of_vbd ~__context ~self in
 			let dbg = Context.string_of_task __context in
@@ -2146,9 +2146,9 @@ let vbd_unplug ~__context ~self force =
 		)
 
 let vbd_eject_hvm ~__context ~self =
-	transform_xenops_exn ~__context
+	let vm = Db.VBD.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
-			let vm = Db.VBD.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;
 			let vbd = md_of_vbd ~__context ~self in
 			info "xenops: VBD.eject %s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id);
@@ -2161,9 +2161,9 @@ let vbd_eject_hvm ~__context ~self =
 		)
 
 let vbd_insert_hvm ~__context ~self ~vdi =
-	transform_xenops_exn ~__context
+	let vm = Db.VBD.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
-			let vm = Db.VBD.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;
 			let vbd = md_of_vbd ~__context ~self in
 			let disk = disk_of_vdi ~__context ~self:vdi |> Opt.unbox in
@@ -2206,9 +2206,9 @@ let md_of_vif ~__context ~self =
 	MD.of_vif ~__context ~vm:(Db.VM.get_record ~__context ~self:vm) ~vif:(Db.VIF.get_record ~__context ~self)
 
 let vif_plug ~__context ~self =
-	transform_xenops_exn ~__context
+	let vm = Db.VIF.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
-			let vm = Db.VIF.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;
 			Events_from_xapi.wait ~__context ~self:vm;
 			let vif = md_of_vif ~__context ~self in
@@ -2236,9 +2236,9 @@ let vm_set_vm_data ~__context ~self =
 		)
 
 let vif_set_locking_mode ~__context ~self =
-	transform_xenops_exn ~__context
+	let vm = Db.VIF.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
-			let vm = Db.VIF.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;
 			let vif = md_of_vif ~__context ~self in
 			info "xenops: VIF.set_locking_mode %s.%s" (fst vif.Vif.id) (snd vif.Vif.id);
@@ -2248,9 +2248,9 @@ let vif_set_locking_mode ~__context ~self =
 		)
 
 let vif_unplug ~__context ~self force =
-	transform_xenops_exn ~__context
+	let vm = Db.VIF.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
-			let vm = Db.VIF.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;
 			let vif = md_of_vif ~__context ~self in
 			info "xenops: VIF.unplug %s.%s" (fst vif.Vif.id) (snd vif.Vif.id);
@@ -2262,7 +2262,8 @@ let vif_unplug ~__context ~self force =
 		)
 
 let vif_move ~__context ~self network =
-	transform_xenops_exn ~__context
+	let vm = Db.VIF.get_VM ~__context ~self in
+	transform_xenops_exn ~__context ~vm
 		(fun () ->
 			let vm = Db.VIF.get_VM ~__context ~self in
 			assert_resident_on ~__context ~self:vm;


### PR DESCRIPTION
This backports the commits made in the xapi-project/xen-api
pull-requests xapi-project/xen-api#2272 and xapi-project/xen-api#2400
by running

```
git cherry-pick -sx b330b201ff89e6d5f45a8cf039eae044a71ad0f9 \
4061224cb16ce9c063437f62f6e6478109ba358f \
19b8b1802007aedfbc20daf131d9c4c015ce46f2 \
6a6fdda292131cb61fa067336bcfb58e7ce62368 \
0264a6ee7920838688b18c8ad87b1c4fd539729b \
e6e8a638bb588d212c19729b778124cc805187ef \
c629308de40d9c80d499a3f5d5ce51a35eec9f7c \
f312b6807ce103b6b38aa3f383c07eb94baabd6a \
7bd9c37cf02472cb6dd019473cc1a5a8bd4d81a1
```

and resolving the many conflicts.
