### PR TITLE
CA-182497: Raise an API error when xs-tools iso mounted on a VM

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -307,6 +307,7 @@ let patch_precheck_failed_prerequisite_missing = "PATCH_PRECHECK_FAILED_PREREQUI
 let patch_precheck_failed_wrong_server_version = "PATCH_PRECHECK_FAILED_WRONG_SERVER_VERSION"
 let patch_precheck_failed_wrong_server_build = "PATCH_PRECHECK_FAILED_WRONG_SERVER_BUILD"
 let patch_precheck_failed_vm_running = "PATCH_PRECHECK_FAILED_VM_RUNNING"
+let patch_precheck_tools_iso_mounted = "PATCH_PRECHECK_FAILED_ISO_MOUNTED"
 let patch_apply_failed = "PATCH_APPLY_FAILED"
 let patch_apply_failed_backup_files_exist = "PATCH_APPLY_FAILED_BACKUP_FILES_EXIST"
 let cannot_find_oem_backup_partition = "CANNOT_FIND_OEM_BACKUP_PARTITION"

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -976,6 +976,8 @@ let _ =
     ~doc:"The patch precheck stage failed: the server is of an incorrect build." ();
   error Api_errors.patch_precheck_failed_vm_running [ "patch" ]
     ~doc:"The patch precheck stage failed: there are one or more VMs still running on the server.  All VMs must be suspended before the patch can be applied." ();
+  error Api_errors.patch_precheck_tools_iso_mounted ["patch"]
+    ~doc:"XenServer Tools ISO must be ejected from all running VMs." ();
 
   error Api_errors.cannot_find_oem_backup_partition []
     ~doc:"The backup partition to stream the updat to cannot be found" ();

--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -621,6 +621,8 @@ let parse_patch_precheck_xml patch = function
         <info>Any message in text - for errors that don't fit into another category</info>
       </error> *)
       raise (Api_errors.Server_error (Api_errors.patch_precheck_failed_unknown_error, [Ref.string_of patch; info]))
+  | Element("error" , [("errorcode","PATCH_PRECHECK_FAILED_ISO_MOUNTED")], [Element ("info",_, [PCData info])]) ->
+      raise (Api_errors.Server_error (Api_errors.patch_precheck_tools_iso_mounted, [Ref.string_of patch; info]))
   | Element ("error", [("errorcode", "PATCH_PRECHECK_FAILED_PREREQUISITE_MISSING")], children) ->
       (* <error errorcode="PATCH_PRECHECK_FAILED_PREREQUISITE_MISSING">
         <prerequisite uuid="ABCD1234-FEED-DEAD-BEEF-000000000000" />


### PR DESCRIPTION
Error "PATCH_PRECHECK_FAILED_ISO_MOUNTED" need to be raised when user
tries to apply PV tools hotfix and xs-tools iso is mounted on a VM.
Duplicate of CA-100559.

Signed-off-by: Akshay Ramani akshay.ramani@citrix.com

Backporting https://github.com/xapi-project/xen-api/pull/1205 to tampa-bugfix
