### PR TITLE
Revert "CA-173358: Remove VBD related data sources from xcp-rrdd"

### DIFF
--- a/ocaml/rrdd/OMakefile
+++ b/ocaml/rrdd/OMakefile
@@ -15,6 +15,9 @@ OCAML_LIBS = $(ROOT)/ocaml/fhs ../idl/ocaml_backend/xapi_client ../xenops/xensto
 
 UseCamlp4(rpc-light.syntax, rrdd_server)
 
+OCAML_CLIBS = blktap3_stats_stubs
+StaticCLibrary(blktap3_stats_stubs, blktap3_stats_stubs)
+
 RRDD = xcp-rrdd
 RRDD_FILES = \
 	../pool_role_shared \
@@ -38,6 +41,7 @@ RRDD_FILES = \
 	rrdd_server \
 	rrdd_monitor \
 	rrdd_stats \
+	blktap3_stats\
 	rrdd_main
 RRDD_TEST = rrdd_test
 RRDD_TEST_FILES = \

--- a/ocaml/rrdd/blktap3_stats.ml
+++ b/ocaml/rrdd/blktap3_stats.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(*
+ * This module extracts the external declaration to make things easier
+ * for a library which might be used elsewhere.
+*)
+
+(** Define an equivalent blktap3 statistics record *)
+type blktap3_stats = {
+	st_ds_req : int64;
+	st_f_req  : int64;
+	st_oo_req : int64;
+	st_rd_req : int64;
+	st_rd_cnt : int64;
+	st_rd_sect: int64;
+	st_rd_sum_usecs : int64;
+	st_rd_max_usecs : int64;
+	st_wr_req : int64;
+	st_wr_cnt : int64;
+	st_wr_sect: int64;
+	st_wr_sum_usecs : int64;
+	st_wr_max_usecs : int64;
+}
+
+(** Obtain a blktap3 statistics record using the stubs *)
+external get_blktap3_stats:
+	filename:string -> blktap3_stats = "stub_get_blktap3_stats"

--- a/ocaml/rrdd/blktap3_stats.mli
+++ b/ocaml/rrdd/blktap3_stats.mli
@@ -1,0 +1,51 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+(**
+ * This module defines an equivalent blktap3 stats record and the
+ * associated API method.
+ *)
+
+(** Attributes associated with the blktap3 stats struct *)
+type blktap3_stats = {
+	(** BLKIF_OP_DISCARD, not currently supported in blktap3, zero always *)
+	st_ds_req : int64;
+	(** BLKIF_OP_FLUSH_DISKCACHE, not currently supported in blktap3, zero always*)
+	st_f_req  : int64;
+	(** Increased each time we fail to allocate memory for a internal 
+	 * request descriptor in response to a ring request. *)
+	st_oo_req : int64;
+	(** Received BLKIF_OP_READ requests. *)
+	st_rd_req : int64;
+	(** Completed BLKIF_OP_READ requests. *)
+	st_rd_cnt : int64;
+	(** Read sectors, after we've forwarded the request to actual storage. *)
+	st_rd_sect: int64;
+	(** Sum of the request response time of all BLKIF_OP_READ *)
+	st_rd_sum_usecs : int64;
+	(** Absolute maximum BLKIF_OP_READ response time *)
+	st_rd_max_usecs : int64;
+	(** Received BLKIF_OP_WRITE requests. *)
+	st_wr_req : int64;
+	(** Completed BLKIF_OP_WRITE requests. *)
+	st_wr_cnt : int64;
+	(** Write sectors, after we've forwarded the request to actual storage. *)
+	st_wr_sect: int64;
+	(** Sum of the request response time of all BLKIF_OP_WRITE *)
+	st_wr_sum_usecs : int64;
+	(** Absolute maximum BLKIF_OP_WRITE response time *)
+	st_wr_max_usecs : int64;
+}
+
+(** Get a blktap3 statistics record *)
+val get_blktap3_stats: filename:string -> blktap3_stats

--- a/ocaml/rrdd/blktap3_stats_stubs.c
+++ b/ocaml/rrdd/blktap3_stats_stubs.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2006-2009 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ */
+
+/*
+  This stubs file retrieves the blkback statistics struct created by
+  blktap3 under '/dev/shm/<vbd3-domid-devid>/statistics' *)
+*/
+
+#include <stdio.h>
+#include <errno.h>
+#include <blktap/blktap3.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/unixsupport.h>
+
+
+CAMLprim value stub_get_blktap3_stats(value filename)
+{
+	
+	CAMLparam1(filename);
+	CAMLlocal1(stats);
+
+	FILE *c_fd;
+	struct blkback_stats c_stats;
+
+	c_fd = fopen(String_val(filename), "rb");
+
+	if (!c_fd) uerror("fopen", Nothing);
+	if (fread(&c_stats, sizeof(struct blkback_stats), 1, c_fd) < 1) uerror("fread", Nothing);
+	
+	stats = caml_alloc_tuple(13);
+
+	Store_field(stats, 0, caml_copy_int64((int64) c_stats.st_ds_req));
+	Store_field(stats, 1, caml_copy_int64((int64) c_stats.st_f_req));
+	Store_field(stats, 2, caml_copy_int64((int64) c_stats.st_oo_req));
+	Store_field(stats, 3, caml_copy_int64((int64) c_stats.st_rd_req));
+	Store_field(stats, 4, caml_copy_int64((int64) c_stats.st_rd_cnt));
+	Store_field(stats, 5, caml_copy_int64((int64) c_stats.st_rd_sect));
+	Store_field(stats, 6, caml_copy_int64((int64) c_stats.st_rd_sum_usecs));
+	Store_field(stats, 7, caml_copy_int64((int64) c_stats.st_rd_max_usecs));
+	Store_field(stats, 8, caml_copy_int64((int64) c_stats.st_wr_req));
+	Store_field(stats, 9, caml_copy_int64((int64) c_stats.st_wr_cnt));
+	Store_field(stats, 10, caml_copy_int64((int64) c_stats.st_wr_sect));
+	Store_field(stats, 11, caml_copy_int64((int64) c_stats.st_wr_sum_usecs));
+	Store_field(stats, 12, caml_copy_int64((int64) c_stats.st_wr_max_usecs));
+
+	fclose(c_fd);
+
+	CAMLreturn(stats);
+
+}

--- a/ocaml/rrdd/rrdd_main.ml
+++ b/ocaml/rrdd/rrdd_main.ml
@@ -372,6 +372,268 @@ let update_netdev doms =
 			 ~description:"Bytes per second sent on all physical interfaces"
 			 ~units:"B/s" ~value:(Rrd.VT_Int64 sum_tx) ~ty:Rrd.Derive ~min:0.0 ~default:true ())
 		 ] @ dss, pifs
+			 
+
+(*****************************************************)
+(* disk related code                                 *)
+(*****************************************************)
+
+(* Record to hold metrics from sysfs *)
+type sysfs_stats = {
+	rd_sect : int64;
+	wr_sect : int64;
+	rd_avg_usecs : int64;
+	wr_avg_usecs : int64;
+}
+
+let update_vbds doms =
+	let open Blktap3_stats in
+	let read_int_file file =
+		let v = ref 0L in
+		try Unixext.readfile_line (fun l -> v := Int64.of_string l) file; !v
+		with _ -> !v
+	in
+	let read_usecs_file file =
+		let vals = ref (0L, 0L, 0L) in
+		try
+			Unixext.readfile_line (fun l ->
+				Scanf.sscanf l "requests: %Ld, avg usecs: %Ld, max usecs: %Ld"
+					(fun a b c -> vals := (a, b, c))
+			) file;
+			!vals
+		with _ -> !vals
+	in
+	let shm_devices_dir = "/dev/shm" in
+	let sysfs_devices_dir = "/sys/devices/" in
+	(* Method to read stats from sysfs *)
+	let read_all_sysfs_stats vbd =
+		let sysfs_stat_tree_exists vbd =
+			let statdir = Printf.sprintf "%s/%s/statistics/" sysfs_devices_dir vbd in
+				try
+					Sys.is_directory statdir
+				with _ -> false
+		in
+		if (sysfs_stat_tree_exists vbd) then
+			begin
+				let statdir = Printf.sprintf "%s/%s/statistics/" sysfs_devices_dir vbd in
+				let rd_file = statdir ^ "rd_sect" in
+				let wr_file = statdir ^ "wr_sect" in
+				let rd_usecs_file = statdir ^ "rd_usecs" in
+				let wr_usecs_file = statdir ^ "wr_usecs" in
+				let rd_sect = read_int_file rd_file in
+				let wr_sect = read_int_file wr_file in
+				let _, rd_avg_usecs, _ = read_usecs_file rd_usecs_file in
+				let _, wr_avg_usecs, _ = read_usecs_file wr_usecs_file in
+				Some({ rd_sect = rd_sect; wr_sect = wr_sect;
+				rd_avg_usecs = rd_avg_usecs; wr_avg_usecs = wr_avg_usecs })
+			end
+		else
+			None
+	in
+	let read_raw_blktap3_stats vbd =
+		try
+			let stat_file = Printf.sprintf "%s/%s/statistics" shm_devices_dir vbd in
+			(* Retrieve blktap3 statistics record *)
+			let stat_rec = get_blktap3_stats stat_file in
+			Some(stat_rec)
+		with _ ->
+			None in
+	let shm_dirs = Array.to_list (Sys.readdir shm_devices_dir) in
+	let shm_vbds =
+		List.filter
+			(fun s -> String.startswith "vbd3-" s) shm_dirs in
+	let sysfs_dirs = Array.to_list (Sys.readdir sysfs_devices_dir) in
+	let sysfs_vbds =
+		List.filter
+			(fun s -> String.startswith "vbd-" s || String.startswith "tap-" s) sysfs_dirs in
+	let vbds = shm_vbds @ sysfs_vbds in
+	List.fold_left (fun acc vbd ->
+		let generate_stats acc blktap3_stat_rec sysfs_stat_rec =
+			let blksize = 512L in
+			let avgqu_normalizer = 1000000L in
+			let istap = String.startswith "tap-" vbd in
+			let isvbd3 = String.startswith "vbd3-" vbd in
+			let domid, devid =
+				if istap then Scanf.sscanf vbd "tap-%d-%d" (fun id devid -> (id, devid))
+				else if isvbd3 then Scanf.sscanf vbd "vbd3-%d-%d" (fun id devid -> (id, devid))
+				else Scanf.sscanf vbd "vbd-%d-%d" (fun id devid -> (id, devid))
+			in
+			let open Device_number in
+			let device_name = devid |> of_xenstore_key |> to_linux_device in
+			let vbd_name = Printf.sprintf "vbd_%s" device_name in
+			(* If blktap fails to cleanup then we might find a backend domid which doesn't
+				 correspond to an active domain uuid. Skip these for now. *)
+			match blktap3_stat_rec, sysfs_stat_rec with
+			|Some(b), Some(s) ->
+					let rd_bytes = Int64.mul (Int64.add b.st_rd_sect s.rd_sect) 256L in
+					let wr_bytes = Int64.mul (Int64.add b.st_wr_sect s.wr_sect) 256L in
+					let b_rd_avg_usecs =
+						if b.st_rd_cnt > 0L then
+							Int64.div b.st_rd_sum_usecs b.st_rd_cnt
+						else 0L in
+					let b_wr_avg_usecs =
+						if b.st_wr_cnt > 0L then
+							Int64.div b.st_wr_sum_usecs b.st_wr_cnt
+						else 0L in
+					let rd_avg_usecs = max b_rd_avg_usecs s.rd_avg_usecs in
+					let wr_avg_usecs = max b_wr_avg_usecs s.wr_avg_usecs in
+					(* Retain old behaviour as handling sysfs becomes important only
+					 * when CAR-133 is in place. CAR-133 attempts to plug raw VDI's
+					 * directly from LVs to blkback. *)
+					let inflight = Int64.add (Int64.sub b.st_rd_req b.st_rd_cnt) (Int64.sub b.st_wr_req b.st_wr_cnt) in
+					let iowait = Int64.to_float (Int64.div (Int64.add b.st_rd_cnt b.st_wr_cnt) (Int64.add b.st_rd_sum_usecs b.st_wr_sum_usecs))  /. 1000. in
+					(* Average Queue Size is computed as the sum of the
+					 * read and write queues' averaged over 5 seconds *)
+					let avgqu_sz = Int64.div (Int64.add b.st_rd_sum_usecs b.st_wr_sum_usecs) avgqu_normalizer in
+					let newacc =
+						try
+							let uuid = uuid_of_domid doms domid in
+							(VM uuid, ds_make ~name:(vbd_name^"_write")
+								~description:("Writes to device '"^device_name^"' in bytes per second")
+								~value:(Rrd.VT_Int64 wr_bytes) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_read")
+								~description:("Reads from device '"^device_name^"' in bytes per second")
+								~value:(Rrd.VT_Int64 rd_bytes) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_read_latency")
+								~description:("Read latency for device '" ^ device_name ^ "' in microseconds")
+								~units:"μs" ~value:(Rrd.VT_Int64 rd_avg_usecs)
+								~ty:Rrd.Gauge ~min:0.0 ~default:false ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_write_latency")
+								~description:("Write latency for device '" ^ device_name ^ "' in microseconds")
+								~value:(Rrd.VT_Int64 wr_avg_usecs) ~ty:Rrd.Gauge ~min:0.0
+								~default:false ~units:"μs" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_inflight")
+								~description:("Number of I/O requests currently in flight")
+								~value:(Rrd.VT_Int64 inflight) ~ty:Rrd.Gauge ~min:0.0 ~default:true
+								~units:"requests" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iowait")
+								~description:("Total I/O wait time (all requests) per second")
+								~value:(Rrd.VT_Float iowait) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"s/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_read")
+								~description:("Read requests per second")
+								~value:(Rrd.VT_Int64 b.st_rd_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_write")
+								~description:("Write requests per second")
+								~value:(Rrd.VT_Int64 b.st_wr_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_total")
+								~description:("I/O Requests per second")
+								~value:(Rrd.VT_Int64 (Int64.add b.st_rd_cnt b.st_wr_cnt))
+								~ty:Rrd.Derive ~min:1.0 ~default:true ~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_io_throughput_total")
+								~description:("All " ^ device_name ^ " I/O")
+								~value:(Rrd.VT_Int64 (Int64.add rd_bytes wr_bytes)) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_avgqu_sz")
+								~description:("Average I/O queue size for "^ device_name)
+								~value:(Rrd.VT_Int64 avgqu_sz) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests" ())::
+							acc
+						with _ -> acc
+					in
+					newacc
+			|Some(b), None ->
+					let rd_bytes = Int64.mul b.st_rd_sect blksize in
+					let wr_bytes = Int64.mul b.st_wr_sect blksize in
+					let rd_avg_usecs =
+						if b.st_rd_cnt > 0L then
+							Int64.div b.st_rd_sum_usecs b.st_rd_cnt
+						else 0L in
+					let wr_avg_usecs =
+						if b.st_wr_cnt > 0L then
+							Int64.div b.st_wr_sum_usecs b.st_wr_cnt
+						else 0L in
+					(* Create variables to hold new statistics *)
+					let inflight = Int64.add (Int64.sub b.st_rd_req b.st_rd_cnt) (Int64.sub b.st_wr_req b.st_wr_cnt) in
+					let iowait = Int64.to_float (Int64.div (Int64.add b.st_rd_cnt b.st_wr_cnt) (Int64.add b.st_rd_sum_usecs b.st_wr_sum_usecs))  /. 1000. in
+					(* Average Queue Size is computed as the sum of the
+					 * read and write queues' averaged over 5 seconds *)
+					let avgqu_sz = Int64.div (Int64.add b.st_rd_sum_usecs b.st_wr_sum_usecs) avgqu_normalizer in
+					let newacc =
+						try
+							let uuid = uuid_of_domid doms domid in
+							(VM uuid, ds_make ~name:(vbd_name^"_write")
+								~description:("Writes to device '"^device_name^"' in bytes per second")
+								~value:(Rrd.VT_Int64 wr_bytes) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_read")
+								~description:("Reads from device '"^device_name^"' in bytes per second")
+								~value:(Rrd.VT_Int64 rd_bytes) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_read_latency")
+								~description:("Read latency for device '" ^ device_name ^ "' in microseconds")
+								~units:"μs" ~value:(Rrd.VT_Int64 rd_avg_usecs)
+								~ty:Rrd.Gauge ~min:0.0 ~default:false ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_write_latency")
+								~description:("Write latency for device '" ^ device_name ^ "' in microseconds")
+								~value:(Rrd.VT_Int64 wr_avg_usecs) ~ty:Rrd.Gauge ~min:0.0
+								~default:false ~units:"μs" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_inflight")
+								~description:("Number of I/O requests currently in flight")
+								~value:(Rrd.VT_Int64 inflight) ~ty:Rrd.Gauge ~min:0.0 ~default:true
+								~units:"requests" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iowait")
+								~description:("Total I/O wait time (all requests) per second")
+								~value:(Rrd.VT_Float iowait) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"s/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_read")
+								~description:("Read requests per second")
+								~value:(Rrd.VT_Int64 b.st_rd_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_write")
+								~description:("Write requests per second")
+								~value:(Rrd.VT_Int64 b.st_wr_cnt) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_iops_total")
+								~description:("I/O Requests per second")
+								~value:(Rrd.VT_Int64 (Int64.add b.st_rd_cnt b.st_wr_cnt))
+								~ty:Rrd.Derive ~min:1.0 ~default:true ~units:"requests/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_io_throughput_total")
+								~description:("All " ^ device_name ^ " I/O")
+								~value:(Rrd.VT_Int64 (Int64.add rd_bytes wr_bytes)) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_avgqu_sz")
+								~description:("Average I/O queue size for "^ device_name)
+								~value:(Rrd.VT_Int64 avgqu_sz) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"requests" ())::
+							acc
+						with _ -> acc
+					in
+					newacc
+			|None, Some(s) ->
+					let rd_bytes = Int64.mul s.rd_sect blksize in
+					let wr_bytes = Int64.mul s.wr_sect blksize in
+					let newacc =
+						try
+							let uuid = uuid_of_domid doms domid in
+							(VM uuid, ds_make ~name:(vbd_name^"_write")
+								~description:("Writes to device '"^device_name^"' in bytes per second")
+								~value:(Rrd.VT_Int64 wr_bytes) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_read")
+								~description:("Reads from device '"^device_name^"' in bytes per second")
+								~value:(Rrd.VT_Int64 rd_bytes) ~ty:Rrd.Derive ~min:0.0 ~default:true
+								~units:"B/s" ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_read_latency")
+								~description:("Read latency for device '" ^ device_name ^ "' in microseconds")
+								~units:"μs" ~value:(Rrd.VT_Int64 s.rd_avg_usecs)
+								~ty:Rrd.Gauge ~min:0.0 ~default:false ())::
+							(VM uuid, ds_make ~name:(vbd_name^"_write_latency")
+								~description:("Write latency for device '" ^ device_name ^ "' in microseconds")
+								~value:(Rrd.VT_Int64 s.wr_avg_usecs) ~ty:Rrd.Gauge ~min:0.0
+								~default:false ~units:"μs" ())::
+							acc
+						with _ -> acc
+					in
+					newacc
+			|None, None -> acc
+		in
+		generate_stats acc (read_raw_blktap3_stats vbd) (read_all_sysfs_stats vbd)
+	) [] vbds
 
 (*****************************************************)
 (* generic code                                      *)
@@ -536,6 +798,7 @@ let read_all_dom0_stats xc =
 		vifs;
 		handle_exn "cache_stats" (fun _ -> read_cache_stats timestamp) [];
 		handle_exn "update_pcpus" (fun _-> update_pcpus xc) [];
+		handle_exn "update_vbds" (fun _ -> update_vbds domains) [];
 		handle_exn "update_loadavg" (fun _ -> [update_loadavg ()]) [];
 		handle_exn "update_memory" (fun _ -> update_memory xc domains) []
 	] in


### PR DESCRIPTION
Reverts xenserver/xen-api#35
