### PR TITLE
CA-192884: Move start/shutdown delays to Xapi_vm

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1326,8 +1326,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let local_fn = Local.VM.clean_shutdown ~vm in
 			with_vm_operation ~__context ~self:vm ~doc:"VM.clean_shutdown" ~op:`clean_shutdown
 				(fun () ->
-					forward_vm_op ~local_fn ~__context ~vm (fun session_id rpc -> Client.VM.clean_shutdown rpc session_id vm);
-					Xapi_vm_helpers.shutdown_delay ~__context ~vm
+					forward_vm_op ~local_fn ~__context ~vm (fun session_id rpc -> Client.VM.clean_shutdown rpc session_id vm)
 				);
 			let uuid = Db.VM.get_uuid ~__context ~self:vm in
 			let message_body =
@@ -1355,8 +1354,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 								do_op_on ~__context ~local_fn:(Local.VM.hard_shutdown ~vm) ~host:suitable_host (fun session_id rpc -> Client.VM.hard_shutdown rpc session_id vm)
 							end
 						else
-							forward_vm_op ~local_fn ~__context ~vm (fun session_id rpc -> Client.VM.shutdown rpc session_id vm);
-					Xapi_vm_helpers.shutdown_delay ~__context ~vm
+							forward_vm_op ~local_fn ~__context ~vm (fun session_id rpc -> Client.VM.shutdown rpc session_id vm)
 				);
 			update_vbd_operations ~__context ~vm;
 			update_vif_operations ~__context ~vm;
@@ -1435,8 +1433,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 						else
 							(* if we're nt suspended then just forward to host that has vm running on it: *)
 							forward_vm_op ~vm in
-					policy ~local_fn ~__context (fun session_id rpc -> Client.VM.hard_shutdown rpc session_id vm);
-					Xapi_vm_helpers.shutdown_delay ~__context ~vm
+					policy ~local_fn ~__context (fun session_id rpc -> Client.VM.hard_shutdown rpc session_id vm)
 				);
 			let uuid = Db.VM.get_uuid ~__context ~self:vm in
 			let message_body =

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1206,7 +1206,6 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 											(fun session_id rpc ->
 												Client.VM.start rpc session_id vm start_paused force) in
 										Cpuid_helpers.populate_cpu_flags ~__context ~vm ~host;
-										Xapi_vm_helpers.start_delay ~__context ~vm;
 										host
 									))) in
 			update_vbd_operations ~__context ~vm;

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -239,14 +239,16 @@ let hard_shutdown ~__context ~vm =
 		Db.VM.set_suspend_VDI ~__context ~self:vm ~value:Ref.null;
 		Xapi_vm_lifecycle.force_state_reset ~__context ~self:vm ~value:`Halted;
 	end else
-	Xapi_xenops.shutdown ~__context ~self:vm None
+	Xapi_xenops.shutdown ~__context ~self:vm None;
+	Xapi_vm_helpers.shutdown_delay ~__context ~vm
 
 let clean_reboot ~__context ~vm =
 	Xapi_xenops.reboot ~__context ~self:vm (Some !Xapi_globs.domain_shutdown_total_timeout)
 
 let clean_shutdown_with_timeout ~__context ~vm timeout =
 	Db.VM.set_ha_always_run ~__context ~self:vm ~value:false;
-	Xapi_xenops.shutdown ~__context ~self:vm (Some timeout)
+	Xapi_xenops.shutdown ~__context ~self:vm (Some timeout);
+	Xapi_vm_helpers.shutdown_delay ~__context ~vm
 
 let clean_shutdown ~__context ~vm =
 	clean_shutdown_with_timeout ~__context ~vm !Xapi_globs.domain_shutdown_total_timeout

--- a/ocaml/xapi/xapi_vm.ml
+++ b/ocaml/xapi/xapi_vm.ml
@@ -197,11 +197,14 @@ let start ~__context ~vm ~start_paused ~force =
 
 	(* If the VM has any vGPUs, gpumon must remain stopped until the
 	 * VM has started. *)
-	match vmr.API.vM_VGPUs with
-	| [] -> Xapi_xenops.start ~__context ~self:vm start_paused
-	| _ ->
-		Xapi_gpumon.with_gpumon_stopped
-			~f:(fun () -> Xapi_xenops.start ~__context ~self:vm start_paused)
+	begin
+		match vmr.API.vM_VGPUs with
+		| [] -> Xapi_xenops.start ~__context ~self:vm start_paused
+		| _ ->
+			Xapi_gpumon.with_gpumon_stopped
+				~f:(fun () -> Xapi_xenops.start ~__context ~self:vm start_paused)
+	end;
+	Xapi_vm_helpers.start_delay ~__context ~vm
 
 (** For VM.start_on and VM.resume_on the message forwarding layer should only forward here
     if 'host' = localhost *)


### PR DESCRIPTION
With the delays called in Message_forwarding, they occur before the task finishes when running on a master but after the task finishes when running on a slave. This leads to inconsistent behaviour when starting and shutting down VM appliances, which watch for their subtasks to complete.
