### PR TITLE
CA-199405: Set DNS before making DHCP request

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -378,6 +378,7 @@ module Interface = struct
 			List.iter (function (name, ({ipv4_conf; ipv4_gateway; ipv6_conf; ipv6_gateway; ipv4_routes; dns=nameservers,domains; mtu;
 				ethtool_settings; ethtool_offload; _} as c)) ->
 				update_config name c;
+				exec (fun () -> set_dns () dbg ~name ~nameservers ~domains);
 				exec (fun () -> set_ipv4_conf () dbg ~name ~conf:ipv4_conf);
 				exec (fun () -> match ipv4_gateway with None -> () | Some gateway ->
 					set_ipv4_gateway () dbg ~name ~address:gateway);
@@ -385,7 +386,6 @@ module Interface = struct
 				(try match ipv6_gateway with None -> () | Some gateway ->
 					set_ipv6_gateway () dbg ~name ~address:gateway with _ -> ());
 				exec (fun () -> set_ipv4_routes () dbg ~name ~routes:ipv4_routes);
-				exec (fun () -> set_dns () dbg ~name ~nameservers ~domains);
 				exec (fun () -> set_mtu () dbg ~name ~mtu);
 				exec (fun () -> bring_up () dbg ~name);
 				exec (fun () -> set_ethtool_settings () dbg ~name ~params:ethtool_settings);


### PR DESCRIPTION
A recent change[1] to support clearing of DNS entries when using Static
mode networking has caused DNS entries to be cleared when using DHCP.

We need to support the following cases:
1. DHCP;
2. Static with non-empty DNS; and
3. Static with empty DNS.

We currently don't support DHCP with a DNS override so we don't need to
consider this in this patch.

This patch changes the order of setting the DNS for the host and calling
dhclient so that the above three use-cases are honoured.

[1]: d49bc77 CA-198824: Allow empty DNS when configuring static IP

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
