### PR TITLE
CA-199404: Only apply DNS settings in Static4 mode

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -378,7 +378,11 @@ module Interface = struct
 			List.iter (function (name, ({ipv4_conf; ipv4_gateway; ipv6_conf; ipv6_gateway; ipv4_routes; dns=nameservers,domains; mtu;
 				ethtool_settings; ethtool_offload; _} as c)) ->
 				update_config name c;
-				exec (fun () -> set_dns () dbg ~name ~nameservers ~domains);
+				exec (fun () ->
+					(* We only apply the DNS settings when in static IPv4 mode to avoid conflicts with DHCP mode.
+					 * The `dns` field should really be an option type so that we don't have to derive the intention
+					 * of the caller by looking at other fields. *)
+					match ipv4_conf with Static4 _ -> set_dns () dbg ~name ~nameservers ~domains | _ -> ());
 				exec (fun () -> set_ipv4_conf () dbg ~name ~conf:ipv4_conf);
 				exec (fun () -> match ipv4_gateway with None -> () | Some gateway ->
 					set_ipv4_gateway () dbg ~name ~address:gateway);


### PR DESCRIPTION
Commit 1a2383c5 did not solve the original problem in case a DHCP config is
applied twice consecutively (for example when the PIF is replugged when xapi is
restarted). The second time round, the dhclient process is already running and
does not reapply the DNS servers after being cleared by the preceeding
`set_dns` call.

This is still not a great solution. The `dns` field should really be an option
type so that we don't have to derive the intention of the caller by looking at
other fields. Changing the type, however, would require us to implement some
upgrade logic first.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
