### PR TITLE
CA-203180: Linux bridge: disable IGMP snooping by default

### DIFF
--- a/ocaml/network/network_server.ml
+++ b/ocaml/network/network_server.ml
@@ -488,6 +488,7 @@ module Bridge = struct
 			| Bridge ->
 				ignore (Brctl.create_bridge name);
 				Brctl.set_forwarding_delay name 0;
+				Sysfs.set_multicast_snooping name false;
 				Opt.iter (Ip.set_mac name) mac;
 				match vlan with
 				| None -> ()

--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -147,6 +147,13 @@ module Sysfs = struct
 		| None -> false
 		| Some features -> (features land flag_NETIF_F_VLAN) <> 0
 
+	let set_multicast_snooping bridge value =
+		try
+			let path = getpath bridge "bridge/multicast_snooping" in
+			write_one_line path (if value then "1" else "0")
+		with _ ->
+			warn "Could not %s IGMP-snooping on bridge %s" (if value then "enable" else "disable") bridge
+
 	let bridge_to_interfaces bridge =
 		try
 			Array.to_list (Sys.readdir (getpath bridge "brif"))


### PR DESCRIPTION
This is a backport of xapi-project/xcp-networkd#71.
