### PR TITLE
CA-207440: Stop daily-license-check cron spamming dead.letter

### DIFF
--- a/scripts/license-check
+++ b/scripts/license-check
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-@LIBEXECDIR@/daily-license-check
+@LIBEXECDIR@/daily-license-check >/dev/null 2>&1
 
 EXITVALUE=$?
 if [ $EXITVALUE != 0 ]; then


### PR DESCRIPTION
We're already logging when there's a failure to syslog using `logger`.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
