### PR TITLE
CP 16939 - add new class PVS_farm, CLI support 

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -1681,3 +1681,33 @@ let vgpu_type_record rpc session_id vgpu_type =
 				~get:(fun () -> string_of_bool (x ()).API.vGPU_type_experimental) ();
 		]
 	}
+
+let pvs_farm_record rpc session_id pvs_farm =
+	let _ref = ref pvs_farm in
+	let empty_record =
+		ToGet (fun () -> Client.PVS_farm.get_record rpc session_id !_ref) in
+	let record = ref empty_record in
+	let x () = lzy_get record in
+		{ setref    = (fun r -> _ref := r ; record := empty_record)
+		; setrefrec = (fun (a,b) -> _ref := a; record := Got b)
+		; record    = x
+		; getref    = (fun () -> !_ref)
+		; fields=
+			[ make_field ~name:"uuid"
+				~get:(fun () -> (x ()).API.pVS_farm_uuid) ()
+			; make_field ~name:"name"
+				~get:(fun () -> (x ()).API.pVS_farm_name)
+				~set:(fun name ->
+					Client.PVS_farm.set_name rpc session_id !_ref name) ()
+			; make_field ~name:"cache_storage"
+				~get:(fun () -> (x ()).API.pVS_farm_cache_storage
+					|> List.map get_uuid_from_ref |> String.concat "; ")
+				~add_to_set:(fun sr_uuid ->
+					let sr = Client.SR.get_by_uuid rpc session_id sr_uuid in
+					Client.PVS_farm.add_cache_storage rpc session_id !_ref sr)
+				~remove_from_set:(fun sr_uuid ->
+					let sr = Client.SR.get_by_uuid rpc session_id sr_uuid in
+					Client.PVS_farm.remove_cache_storage rpc session_id !_ref sr)
+				()
+			]
+		}

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -18,7 +18,7 @@ open Datamodel_types
 (* IMPORTANT: Please bump schema vsn if you change/add/remove a _field_.
               You do not have to bump vsn if you change/add/remove a message *)
 let schema_major_vsn = 5
-let schema_minor_vsn = 100
+let schema_minor_vsn = 101
 
 (* Historical schema versions just in case this is useful later *)
 let rio_schema_major_vsn = 5
@@ -150,6 +150,10 @@ let _pgpu = "PGPU"
 let _gpu_group = "GPU_group"
 let _vgpu = "VGPU"
 let _vgpu_type = "VGPU_type"
+let _pvs_farm = "PVS_farm"
+let _pvs_server = "PVS_server"
+let _pvs_proxy = "PVS_proxy"
+
 
 (** All the various static role names *)
 
@@ -211,6 +215,13 @@ let get_product_releases in_product_since =
       [] -> raise UnspecifiedRelease
     | x::xs -> if x=in_product_since then "closed"::x::xs else go_through_release_order xs
   in go_through_release_order release_order
+
+let dundee_plus_release =
+	{ internal = get_product_releases rel_dundee_plus
+	; opensource=get_oss_releases None
+	; internal_deprecated_since=None
+	}
+
 
 let dundee_release =
 	{ internal = get_product_releases rel_dundee
@@ -8638,6 +8649,103 @@ let vgpu_type =
 		]
 	()
 
+module PVS_farm = struct
+	let lifecycle = [Prototyped, rel_dundee_plus, ""]
+
+	let introduce = call
+		~name:"introduce"
+		~doc:"Introduce new PVS farm"
+		~result:(Ref _pvs_farm, "the new PVS farm")
+		~params:
+		[ String,"name","name of the PVS farm"
+		]
+		~lifecycle
+		~allowed_roles:_R_POOL_OP
+		()
+
+	let forget = call
+		~name:"forget"
+		~doc:"Remove a farm's meta data"
+		~params:
+		[ Ref _pvs_farm, "self", "this PVS farm"
+		]
+		~lifecycle
+		~allowed_roles:_R_POOL_OP
+		()
+
+
+	let set_name = call
+		~name:"set_name"
+		~doc:"Update the name of the PVS farm"
+		~params:
+		[ Ref _pvs_farm, "self", "this PVS farm"
+		; String, "value", "name to be used"
+		]
+		~lifecycle
+		~allowed_roles:_R_POOL_OP
+		()
+
+	let add_cache_storage = call
+		~name:"add_cache_storage"
+		~doc:"Add a cache SR for the proxies on the farm"
+		~params:
+		[ Ref _pvs_farm, "self", "this PVS farm"
+		; Ref _sr, "value", "SR to be used"
+		]
+		~lifecycle
+		~allowed_roles:_R_POOL_OP
+		()
+
+	let remove_cache_storage = call
+		~name:"remove_cache_storage"
+		~doc:"Remove a cache SR for the proxies on the farm"
+		~params:
+		[ Ref _pvs_farm, "self", "this PVS farm"
+		; Ref _sr, "value", "SR to be removed"
+		]
+		~lifecycle
+		~allowed_roles:_R_POOL_OP
+		()
+
+	let obj =
+		let null_str = Some (VString "") in
+		let null_set = Some (VSet []) in
+		create_obj
+		~name: _pvs_farm
+		~descr:"machines serving blocks of data for provisioning VMs"
+		~doccomments:[]
+		~gen_constructor_destructor:false
+		~gen_events:true
+		~in_db:true
+		~lifecycle
+		~persist:PersistEverything
+		~in_oss_since:None
+		~messages_default_allowed_roles:_R_POOL_OP
+		~contents:
+		[ uid     _pvs_farm ~lifecycle
+
+		; field   ~qualifier:StaticRO ~lifecycle
+		          ~ty:String "name" ~default_value:null_str
+		          "Name of the PVS farm. Must match name configured in PVS"
+
+		; field   ~qualifier:DynamicRO ~lifecycle
+		          ~ty:(Set (Ref _sr)) "cache_storage" ~default_value:null_set
+		          ~ignore_foreign_key:true
+		          "The SR used by PVS proxy for the cache"
+
+		(* add fields servers, proxies once the classes are defined *)
+		]
+		~messages:
+		[ introduce
+		; forget
+		; set_name
+		; add_cache_storage
+		; remove_cache_storage
+		]
+		()
+end
+let pvs_farm = PVS_farm.obj
+
 (******************************************************************************************)
 
 (** All the objects in the system in order they will appear in documentation: *)
@@ -8696,6 +8804,7 @@ let all_system =
 		gpu_group;
 		vgpu;
 		vgpu_type;
+		pvs_farm;
 	]
 
 (** These are the pairs of (object, field) which are bound together in the database schema *)
@@ -8857,6 +8966,7 @@ let expose_get_all_messages_for = [
 	_vgpu;
 	_vgpu_type;
 	_dr_task;
+	_pvs_farm;
 ]
 
 let no_task_id_for = [ _task; (* _alert; *) _event ]

--- a/ocaml/idl/datamodel_types.ml
+++ b/ocaml/idl/datamodel_types.ml
@@ -53,6 +53,7 @@ let rel_creedence = "creedence"
 let rel_cream = "cream"
 let rel_indigo = "indigo"
 let rel_dundee = "dundee"
+let rel_dundee_plus = "dundee-plus"
 let rel_ely = "ely"
 
 let release_order =
@@ -75,6 +76,7 @@ let release_order =
 	; rel_cream
 	; rel_indigo
 	; rel_dundee
+	; rel_dundee_plus
 	; rel_ely
 	]
 

--- a/ocaml/xapi/OMakefile
+++ b/ocaml/xapi/OMakefile
@@ -277,6 +277,7 @@ XAPI_MODULES = $(COMMON) \
 	../util/rpc_retry \
 	xapi \
 	cluster_stack_constraints \
+	xapi_pvs_farm \
 
 OCamlProgram(xapi, xapi_main $(XAPI_MODULES))
 

--- a/ocaml/xapi/api_server.ml
+++ b/ocaml/xapi/api_server.ml
@@ -83,8 +83,8 @@ module Actions = struct
 	module GPU_group = Xapi_gpu_group
 	module VGPU = Xapi_vgpu
 	module VGPU_type = Xapi_vgpu_type
+	module PVS_farm = Xapi_pvs_farm
 end
-
 (** Use the server functor to make an XML-RPC dispatcher. *)
 module Forwarder = Message_forwarding.Forward (Actions)
 module Server = Server.Make (Actions) (Forwarder)

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -2615,8 +2615,24 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
 			help="Enable thin-provisioning on an LVHD SR.";
 			implementation=No_fd Cli_operations.lvhd_enable_thin_provisioning;
 			flags=[];
+		};
+		"pvs-farm-introduce",
+		{
+			reqd=["name"];
+			optn=[];
+			help="introduce new PVS farm";
+			implementation=No_fd Cli_operations.PVS_farm.introduce;
+			flags=[];
+		};
+		"pvs-farm-forget",
+		{
+			reqd=["uuid"];
+			optn=[];
+			help="forget a PVS farm";
+			implementation=No_fd Cli_operations.PVS_farm.forget;
+			flags=[];
 		}
-  ]
+	]
 
 let cmdtable : (string, cmd_spec) Hashtbl.t =
   Hashtbl.create 50

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -4649,3 +4649,17 @@ let lvhd_enable_thin_provisioning printer rpc session_id params =
 	let allocation_quantum = Record_util.bytes_of_string "allocation-quantum" (List.assoc "allocation-quantum" params) in
 	let ref = Client.SR.get_by_uuid rpc session_id uuid in
 	Client.LVHD.enable_thin_provisioning rpc session_id ref initial_allocation allocation_quantum
+
+module PVS_farm = struct
+	let introduce printer rpc session_id params =
+		let name  = List.assoc "name" params in
+		let ref   = Client.PVS_farm.introduce ~rpc ~session_id ~name in
+		let uuid  = Client.PVS_farm.get_uuid rpc session_id ref in
+		printer (Cli_printer.PList [uuid])
+
+	let forget printer rpc session_id params =
+		let uuid  = List.assoc "uuid" params in
+		let ref   = Client.PVS_farm.get_by_uuid ~rpc ~session_id ~uuid in
+		Client.PVS_farm.forget rpc session_id ref
+end
+

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -3851,5 +3851,27 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 
 	module VGPU_type = struct end
 	module LVHD = struct end
+
+	module PVS_farm = struct
+		let introduce ~__context ~name =
+			info "PVS_farm.introduce %s" name;
+			Local.PVS_farm.introduce ~__context ~name
+
+		let forget ~__context ~self =
+			info "PVS_farm.forget";
+			Local.PVS_farm.forget ~__context ~self
+
+		let set_name ~__context ~self ~value =
+			info "PVS_farm.set_name %s" value;
+			Local.PVS_farm.set_name ~__context ~self ~value
+
+		let add_cache_storage ~__context ~self ~value =
+			info "PVS_farm.add_cache_storage";
+			Local.PVS_farm.add_cache_storage ~__context ~self ~value
+
+		let remove_cache_storage ~__context ~self ~value =
+			info "PVS_farm.remove_cache_storage";
+			Local.PVS_farm.remove_cache_storage ~__context ~self ~value
+	end
 end
 

--- a/ocaml/xapi/xapi_pvs_farm.ml
+++ b/ocaml/xapi/xapi_pvs_farm.ml
@@ -1,0 +1,38 @@
+(*
+ * Copyright (C) 2016 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* This module implements methods for the PVS_farm class *)
+
+module D = Debug.Make(struct let name = "xapi_pvs_farm" end)
+
+let not_implemented x =
+  raise (Api_errors.Server_error (Api_errors.not_implemented, [ x ]))
+
+let introduce ~__context ~name =
+  not_implemented "PVS_farm.introduce"
+
+let forget ~__context ~self =
+  not_implemented "PVS_farm.forget"
+
+let set_name ~__context ~self ~value =
+  not_implemented "PVS_farm.set_name"
+
+let add_cache_storage ~__context ~self ~value =
+  not_implemented "PVS_farm.add_cache_storage"
+
+let remove_cache_storage ~__context ~self ~value =
+  not_implemented "PVS_farm.remove_cache_storage"
+
+
+


### PR DESCRIPTION
This PR defines a new class `PVS_farm` for PVS Direct and adds it to the CLI. Two fields are not yet defined because they depend on other, not-yet defined classes. The definition refers to a `dundee-plus` release as suggested by @robhoes.
