### PR TITLE
Don't throw away the backtrace from Xenopsd

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1735,7 +1735,17 @@ let transform_xenops_exn ~__context ~vm f =
 		) fmt in
 	try
 		f ()
-	with
+	with e ->
+		Backtrace.is_important e;
+		let reraise code params =
+			error "Re-raising as %s [ %s ]" code (String.concat "; " params);
+			let e' = Api_errors.Server_error(code, params) in
+			Backtrace.reraise e e' in
+		let internal fmt = Printf.kprintf
+			(fun x ->
+				reraise Api_errors.internal_error [ x ]
+			) fmt in
+		begin match e with
 		| Internal_error msg -> internal "xenopsd internal error: %s" msg
 		| Already_exists(thing, id) -> internal "Object with type %s and id %s already exists in xenopsd" thing id
 		| Does_not_exist(thing, id) -> internal "Object with type %s and id %s does not exist in xenopsd" thing id
@@ -1783,6 +1793,8 @@ let transform_xenops_exn ~__context ~vm f =
 			reraise Api_errors.task_cancelled [ Ref.string_of task ]
 		| Storage_backend_error(code, params) -> reraise code params
 		| PCIBack_not_loaded -> internal "pciback has not loaded"
+		| e -> raise e
+		end
 
 let refresh_vm ~__context ~self =
 	let id = id_of_vm ~__context ~self in


### PR DESCRIPTION
Signed-off-by: Si Beaumont simon.beaumont@citrix.com

Conflicts:
    ocaml/xapi/xapi_xenops.ml

Signed-off-by: Euan Harris euan.harris@citrix.com
