### PR TITLE
CP 17650 implement PVS_farm.set_name

### DIFF
--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -520,6 +520,5 @@ let pvs_farm_contains_servers = "PVS_FARM_CONTAINS_SERVERS"
 let pvs_farm_sr_already_added = "PVS_FARM_SR_ALREADY_ADDED"
 let pvs_farm_sr_is_in_use = "PVS_FARM_SR_IS_IN_USE"
 let sr_not_in_pvs_farm = "SR_NOT_IN_PVS_FARM"
-let pvs_farm_cant_set_name = "PVS_FARM_CANT_SET_NAME"
 
 

--- a/ocaml/idl/api_errors.ml
+++ b/ocaml/idl/api_errors.ml
@@ -520,5 +520,6 @@ let pvs_farm_contains_servers = "PVS_FARM_CONTAINS_SERVERS"
 let pvs_farm_sr_already_added = "PVS_FARM_SR_ALREADY_ADDED"
 let pvs_farm_sr_is_in_use = "PVS_FARM_SR_IS_IN_USE"
 let sr_not_in_pvs_farm = "SR_NOT_IN_PVS_FARM"
+let pvs_farm_cant_set_name = "PVS_FARM_CANT_SET_NAME"
 
 

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1344,7 +1344,7 @@ let _ =
 
 	(* PVS errors *)
 	error Api_errors.pvs_farm_contains_running_proxies ["proxies"]
-		~doc:"The PVS farm contains running proxies and cannot be forgotten." ();
+		~doc:"The PVS farm contains running proxies." ();
 
 	error Api_errors.pvs_farm_contains_servers ["servers"]
 		~doc:"The PVS farm contains servers and cannot be forgotten."
@@ -1360,10 +1360,6 @@ let _ =
 
 	error Api_errors.pvs_farm_sr_is_in_use ["farm"; "SR"]
 		~doc:"The SR is in use by the farm and cannot be removed."
-		();
-
-	error Api_errors.pvs_farm_cant_set_name ["farm"]
-		~doc:"The name of the farm can't be set while proxies are active."
 		()
 
 let _ =

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -1360,8 +1360,11 @@ let _ =
 
 	error Api_errors.pvs_farm_sr_is_in_use ["farm"; "SR"]
 		~doc:"The SR is in use by the farm and cannot be removed."
-		()
+		();
 
+	error Api_errors.pvs_farm_cant_set_name ["farm"]
+		~doc:"The name of the farm can't be set while proxies are active."
+		()
 
 let _ =
     message (fst Api_messages.ha_pool_overcommitted) ~doc:"Pool has become overcommitted: it can no longer guarantee to restart protected VMs if the configured number of hosts fail." ();

--- a/ocaml/test/test_pvs_farm.ml
+++ b/ocaml/test/test_pvs_farm.ml
@@ -160,6 +160,21 @@ let test_remove_shared_sr () =
 			(fun () -> XF.remove_cache_storage ~__context ~self:farm ~value:sr1)
 		)
 
+let test_set_name () =
+	let module XF = Xapi_pvs_farm in
+	let module DF = Db.PVS_farm  in
+	let __context = make_test_database () in
+	let name1     = "name1" in
+	let name2     = "name2" in
+	let farm      = XF.introduce ~__context ~name:name1 in
+		( assert_equal name1 (DF.get_name ~__context ~self:farm)
+		; XF.set_name ~__context ~self:farm ~value:name2
+		; assert_equal name2 (DF.get_name ~__context ~self:farm)
+		; ignore@@make_pvs_proxy ~__context ~farm:farm ~currently_attached:true ()
+		; assert_raises_api_error Api_errors.pvs_farm_cant_set_name
+			(fun () -> XF.set_name ~__context ~self:farm ~value:name1)
+		)
+
 
 let test =
 	"test_pvs_farm" >:::
@@ -177,5 +192,6 @@ let test =
 			"test_add_mixed_sr"     >:: test_add_mixed_sr;
 			"test_remove_local_sr"  >:: test_remove_local_sr;
 			"test_remove_shared_sr" >:: test_remove_shared_sr;
+			"test_set_name"         >:: test_set_name;
 
 		]

--- a/ocaml/test/test_pvs_farm.ml
+++ b/ocaml/test/test_pvs_farm.ml
@@ -171,7 +171,7 @@ let test_set_name () =
 		; XF.set_name ~__context ~self:farm ~value:name2
 		; assert_equal name2 (DF.get_name ~__context ~self:farm)
 		; ignore@@make_pvs_proxy ~__context ~farm:farm ~currently_attached:true ()
-		; assert_raises_api_error Api_errors.pvs_farm_cant_set_name
+		; assert_raises_api_error Api_errors.pvs_farm_contains_running_proxies
 			(fun () -> XF.set_name ~__context ~self:farm ~value:name1)
 		)
 

--- a/ocaml/xapi/xapi_pvs_farm.ml
+++ b/ocaml/xapi/xapi_pvs_farm.ml
@@ -54,7 +54,7 @@ let forget ~__context ~self =
 let set_name ~__context ~self ~value =
 	let px = proxies ~__context ~self in
 	if px <> [] then
-		api_error E.pvs_farm_cant_set_name [Ref.string_of self]
+		api_error E.pvs_farm_contains_running_proxies (List.map Ref.string_of px)
 	else
 		Db.PVS_farm.set_name ~__context ~self ~value
 

--- a/ocaml/xapi/xapi_pvs_farm.ml
+++ b/ocaml/xapi/xapi_pvs_farm.ml
@@ -54,8 +54,7 @@ let forget ~__context ~self =
 let set_name ~__context ~self ~value =
 	let px = proxies ~__context ~self in
 	if px <> [] then
-		api_error E.pvs_farm_contains_running_proxies
-			(List.map Ref.string_of px)
+		api_error E.pvs_farm_cant_set_name [Ref.string_of self]
 	else
 		Db.PVS_farm.set_name ~__context ~self ~value
 


### PR DESCRIPTION
- use a specific error message
- implement a unit test

I'm not sure we should prevent using an empty string as a name. We always have uuids but the documentation says about the name of a PVS farm: `Name of the PVS farm. This must match the name of the farm as configured in PVS.` This suggests the name has more significance than names have otherwise. Currently the implementation doesn't check for the empty string.
