### PR TITLE
CA-214121: Move gpg pubkeys from xapi-core to -gpg-keys

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -86,6 +86,7 @@ $(OUTPUT_CLI_RT) $(OUTPUT_SDK): $(MY_MAIN_PACKAGES)/.dirstamp $(RPM_DIRECTORIES)
 	cp $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/xapi-tests-*.rpm $(MY_MAIN_PACKAGES)
 	cp $(RPM_RPMSDIR)/*/xapi-www-*.rpm $(MY_MAIN_PACKAGES)
 	cp $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/xapi-xe-*.rpm $(MY_MAIN_PACKAGES)
+	cp $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/xapi-gpg-keys-*.rpm $(MY_MAIN_PACKAGES)
 
 .PHONY: clean
 clean:

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -76,6 +76,15 @@ BuildRequires: systemd
 %description core
 This package contains the xapi toolstack.
 
+%package gpg-keys
+Summary: gpg public keyring and trust DB
+Group: System/Hypervisor
+
+%description gpg-keys
+GPG public keyring (and trust DB) used for verifying the
+signatures of hotfix packages and of file-based licences.
+(There is also an empty private keyring.)
+
 %package xe
 Summary: The xapi toolstack CLI
 Group: System/Hypervisor
@@ -280,9 +289,6 @@ esac
 @OPTDIR@/bin/xe-enable-ipv6
 /etc/bash_completion.d/xe-switch-network-backend
 @OPTDIR@/bin/xsh
-@OPTDIR@/gpg/pubring.gpg
-@OPTDIR@/gpg/secring.gpg
-@OPTDIR@/gpg/trustdb.gpg
 /etc/xensource/bugtool/xapi.xml
 /etc/xensource/bugtool/xapi/stuff.xml
 /etc/xensource/bugtool/xenopsd.xml
@@ -358,6 +364,11 @@ esac
 @OPTDIR@/bin/xe
 /usr/bin/xe
 /etc/bash_completion.d/xe
+
+%files gpg-keys
+%config(noreplace) @OPTDIR@/gpg/pubring.gpg
+%config(noreplace) @OPTDIR@/gpg/secring.gpg
+%config(noreplace) @OPTDIR@/gpg/trustdb.gpg
 
 %files tests
 %defattr(-,root,root,-)


### PR DESCRIPTION
Also mark them %config(noreplace) in the RPM specfile,
and include the new xapi-gpg-keys package on the installation ISO.

This means that future upgrades of the xapi-core package will not
do anything to these gpg key-related files.

Unfortunately the first upgrade from the original Dundee xapi-core
will delete the files though, so if they need to be preserved then
this must be handled separately.
