### PR TITLE
CA-214975: don't reset VDIs on assume-failed

### DIFF
--- a/scripts/10resetvdis
+++ b/scripts/10resetvdis
@@ -28,7 +28,6 @@ case "$REASON" in
 		reset
 		;;
 	assume-failed)
-		reset
 		;;
 	clean-shutdown)
 		;;


### PR DESCRIPTION
Since xapi's DB GC's logic to determine whether a host has failed takes a while
to see the first heartbeat from each host, it calls the
host-post-declare-scripts with reason="assume-failed" on each host.

This means that the "assume-failed" logic is called for every slave after every
toolstack start on the master.

Even if "assume-failed" is used on appropriate occasions, resetting the VDIs is
still dangerous because any VMs running on a slave will be treated as not being
attached, which can cause the SM layer to make invalid assumptions, possibly
leading to data loss and corruption.

Signed-off-by: Jonathan Davies jonathan.davies@citrix.com
Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
Reviewed-by: Alex Brett alex.brett@citrix.com
