### PR TITLE
CP-18657: Add alerts for pvs proxy setup failures.

### DIFF
--- a/ocaml/client_records/records.ml
+++ b/ocaml/client_records/records.ml
@@ -216,7 +216,7 @@ let message_record rpc session_id message =
 	make_field ~name:"uuid"         ~get:(fun () -> (x ()).API.message_uuid) ();
 	make_field ~name:"name"         ~get:(fun () -> (x ()).API.message_name) ();
 	make_field ~name:"priority"     ~get:(fun () -> Int64.to_string (x ()).API.message_priority) ();
-	make_field ~name:"class"        ~get:(fun () -> match (x ()).API.message_cls with `VM -> "VM" | `Host -> "Host" | `SR -> "SR" | `Pool -> "Pool" | `VMPP -> "VMPP") ();
+	make_field ~name:"class"        ~get:(fun () -> match (x ()).API.message_cls with `VM -> "VM" | `Host -> "Host" | `SR -> "SR" | `Pool -> "Pool" | `VMPP -> "VMPP" | `PVS_proxy -> "PVS_proxy") ();
 	make_field ~name:"obj-uuid"     ~get:(fun () -> (x ()).API.message_obj_uuid) ();
 	make_field ~name:"timestamp"    ~get:(fun () -> Date.to_string (x ()).API.message_timestamp) ();
 	make_field ~name:"body"         ~get:(fun () -> (x ()).API.message_body) ();

--- a/ocaml/idl/api_messages.ml
+++ b/ocaml/idl/api_messages.ml
@@ -92,6 +92,10 @@ let v6_rejected = addMessage "LICENSE_NOT_AVAILABLE" 2L
 let v6_comm_error = addMessage "LICENSE_SERVER_UNREACHABLE" 2L
 let v6_license_server_version_obsolete = addMessage "LICENSE_SERVER_VERSION_OBSOLETE" 2L
 
+(* PVS alerts *)
+let pvs_proxy_no_cache_sr_available = addMessage "PVS_PROXY_NO_CACHE_SR_AVAILABLE" 3L (* No cache storage available for pvs site on the host *)
+let pvs_proxy_setup_failed = addMessage "PVS_PROXY_SETUP_FAILED" 3L (* Setting up pvs proxy rules or pvs proxy daemon initialisation failed internally *)
+
 (* VMPP message types *)
 let vmpp_snapshot_lock_failed = addMessage "VMPP_SNAPSHOT_LOCK_FAILED" 3L (*'The snapshot phase is already executing for this protection policy. Please try again later'*)
 let vmpp_snapshot_succeeded = addMessage "VMPP_SNAPSHOT_SUCCEEDED" 5L (*'Successfully performed the snapshot phase of the protection policy'*)

--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -8157,6 +8157,7 @@ let message =
 		   "SR", "SR";
 		   "Pool","Pool";
        "VMPP","VMPP";
+       "PVS_proxy","PVS_proxy";
     ])
   in
   let create = call

--- a/ocaml/xapi/pvs_proxy_control.ml
+++ b/ocaml/xapi/pvs_proxy_control.ml
@@ -129,8 +129,25 @@ let start_proxy ~__context vif proxy =
 	with e ->
 		let reason =
 			match e with
-			| Xapi_pvs_cache.No_cache_sr_available -> "no PVS cache SR available"
-			| Network_interface.PVS_proxy_connection_error -> "unable to connect to PVS proxy daemon"
+			| Xapi_pvs_cache.No_cache_sr_available ->
+				let proxy_uuid = Db.PVS_proxy.get_uuid ~__context ~self:proxy in
+				let body = Printf.sprintf "Unable to setup PVS-proxy %s for VIF %s: no cache storage found on PVS-site %s for host %s."
+					proxy_uuid (Db.VIF.get_uuid ~__context ~self:vif)
+					(Db.PVS_site.get_name ~__context ~self:(Db.PVS_proxy.get_site ~__context ~self:proxy))
+					(Db.Host.get_name_label ~__context ~self:(Helpers.get_localhost ~__context)) in
+				let (name, priority) = Api_messages.pvs_proxy_no_cache_sr_available in
+				Helpers.call_api_functions ~__context (fun rpc session_id ->
+					ignore(Client.Client.Message.create ~rpc ~session_id ~name  ~priority ~cls:`PVS_proxy ~obj_uuid:proxy_uuid  ~body));
+				"no PVS cache SR available"
+			| Network_interface.PVS_proxy_connection_error ->
+				let proxy_uuid = Db.PVS_proxy.get_uuid ~__context ~self:proxy in
+				let body = Printf.sprintf "Failed to setup PVS-proxy %s for VIF %s on host %s due to an internal error"
+					proxy_uuid (Db.VIF.get_uuid ~__context ~self:vif)
+					(Db.Host.get_name_label ~__context ~self:(Helpers.get_localhost ~__context)) in
+				let (name, priority) = Api_messages.pvs_proxy_setup_failed in
+				Helpers.call_api_functions ~__context (fun rpc session_id ->
+					ignore(Client.Client.Message.create ~rpc ~session_id ~name ~priority ~cls:`PVS_proxy ~obj_uuid:proxy_uuid ~body));
+				"unable to connect to PVS proxy daemon"
 			| Api_errors.Server_error (code, args) when
 					code = Api_errors.license_restriction
 					&& args = [Features.(name_of_feature PVS_proxy)] ->

--- a/ocaml/xapi/xapi_message.ml
+++ b/ocaml/xapi/xapi_message.ml
@@ -53,6 +53,7 @@ let class_to_string cls =
     | `SR -> "SR" 
     | `Pool -> "Pool"
     | `VMPP -> "VMPP" 
+    | `PVS_proxy -> "PVS_proxy"
     | _ -> "unknown"
 
 let string_to_class str = 
@@ -62,6 +63,7 @@ let string_to_class str =
     | "SR" -> `SR
     | "Pool" -> `Pool
     | "VMPP" -> `VMPP
+    | "PVS_proxy" -> `PVS_proxy
     | _ -> failwith "Bad type"
 
 (* We use the timestamp to name the file. For consistency, use this function *)
@@ -222,6 +224,7 @@ let check_uuid ~__context ~cls ~uuid =
 	  | `SR -> ignore(Db.SR.get_by_uuid ~__context ~uuid)
 	  | `Pool -> ignore(Db.Pool.get_by_uuid ~__context ~uuid)
 	  | `VMPP -> ignore(Db.VMPP.get_by_uuid ~__context ~uuid)
+	  | `PVS_proxy -> ignore(Db.PVS_proxy.get_by_uuid ~__context ~uuid)
 	);
 	true
   with _ ->

--- a/ocaml/xapi/xapi_pvs_proxy.ml
+++ b/ocaml/xapi/xapi_pvs_proxy.ml
@@ -33,7 +33,15 @@ let create ~__context ~site ~vIF ~prepopulate =
 	if Db.VIF.get_currently_attached ~__context ~self:vIF then begin
 		Pvs_proxy_control.start_proxy ~__context vIF pvs_proxy;
 		if Db.PVS_proxy.get_currently_attached ~__context ~self:pvs_proxy then
-			Xapi_xenops.vif_set_pvs_proxy ~__context ~self:vIF true
+			try
+				Xapi_xenops.vif_set_pvs_proxy ~__context ~self:vIF true
+			with e ->
+				let body = Printf.sprintf "Failed to setup PVS-proxy %s for VIF %s due to an internal error"
+					uuid (Db.VIF.get_uuid ~__context ~self:vIF) in
+				let (name, priority) = Api_messages.pvs_proxy_setup_failed in
+				Helpers.call_api_functions ~__context (fun rpc session_id ->
+					ignore(Client.Client.Message.create ~rpc ~session_id ~name ~priority ~cls:`PVS_proxy ~obj_uuid:uuid ~body));
+				error "Unable to setup PVS proxy for vif %s: %s." (Ref.string_of vIF) (ExnHelper.string_of_exn e)
 	end;
 	pvs_proxy
 


### PR DESCRIPTION
1) PVS_PROXY_NO_CACHE_SR_AVAILABLE - When no cache storage available for pvs site
while starting a proxy.
2) PVS_PROXY_SETUP_FAILED - When setting up pvs proxy rules or proxy daemon
initialisation failed internally.

Signed-off-by: Sharad Yadav sharad.yadav@citrix.com
