### PR TITLE
CP-18752: Add pool_update.resync_host functionality.

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3933,7 +3933,7 @@ let pool_update_precheck = call
   ~in_product_since:rel_ely
   ~params:[ Ref _pool_update, "self", "The update whose prechecks will be run"; Ref _host, "host", "The host to run the prechecks on." ]
   ~allowed_roles:_R_POOL_OP
-  ~forward_to:(HostExtension "Pool_update.precheck")
+  ~forward_to:(HostExtension "pool_update.precheck")
   ()
 
 let pool_update_apply = call
@@ -3943,7 +3943,7 @@ let pool_update_apply = call
   ~in_product_since:rel_ely
   ~params:[ Ref _pool_update, "self", "The update to apply"; Ref _host, "host", "The host to apply the update to." ]
   ~allowed_roles:_R_POOL_OP
-  ~forward_to:(HostExtension "Pool_update.apply")
+  ~forward_to:(HostExtension "pool_update.apply")
   ()
 
 let pool_update_pool_apply = call
@@ -4006,6 +4006,16 @@ let pool_update_detach = call
   ~allowed_roles:_R_POOL_OP
   ()
 
+let pool_update_resync_host = call
+  ~name:"resync_host"
+  ~hide_from_docs:true
+  ~doc:"Resync the applied updates of the host"
+  ~in_oss_since:None
+  ~in_product_since:rel_ely
+  ~params:[ Ref _host, "host", "The host to resync the applied updates"]
+  ~allowed_roles:_R_POOL_OP
+  ()
+
 let pool_update =
   create_obj ~in_db:true
     ~in_product_since:rel_ely
@@ -4030,6 +4040,7 @@ let pool_update =
     	pool_update_destroy;
     	pool_update_attach;
     	pool_update_detach;
+    	pool_update_resync_host;
     ]
     ~contents:
     [ uid       ~in_oss_since:None _pool_update;
@@ -8957,7 +8968,7 @@ let all_relations =
     (_host_patch, "host"), (_host, "patches");
     (_host_patch, "pool_patch"), (_pool_patch, "host_patches");
 
-    (_pool_update, "hosts"), (_host, "updates");
+    (_host, "updates"), (_pool_update, "hosts");
 
     (_subject, "roles"), (_subject, "roles");
     (*(_subject, "roles"), (_role, "subjects");*)

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2682,6 +2682,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 			let local_fn = Local.Pool_update.detach ~self ~host in
 			do_op_on ~local_fn ~__context ~host
 				(fun session_id rpc -> Client.Pool_update.detach rpc session_id self host)
+
+		let resync_host ~__context ~host =
+			info "Pool_update.resync_host: host = '%s'" (host_uuid ~__context host);
+			let local_fn = Local.Pool_update.resync_host ~host in
+			do_op_on ~local_fn ~__context ~host
+				(fun session_id rpc -> Client.Pool_update.resync_host rpc session_id host)
 	end
 
 	module Host_metrics = struct

--- a/ocaml/xapi/xapi.ml
+++ b/ocaml/xapi/xapi.ml
@@ -996,6 +996,8 @@ let server_init() =
           (fun () -> event_hook_auth_on_xapi_initialize_async ~__context);
       "Cleanup attached pool_updates when start", [ Startup.NoExnRaising ],
           (fun () -> Helpers.call_api_functions ~__context (fun rpc session_id -> Xapi_pool_update.detach_attached_updates __context));
+      "Resync the applied updates of the host when start", [ Startup.NoExnRaising ],
+          (fun () -> Helpers.call_api_functions ~__context (fun rpc session_id -> Xapi_pool_update.resync_host __context (Helpers.get_localhost ~__context)));
     ];
 
     debug "startup: startup sequence finished");

--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -376,3 +376,14 @@ let detach_attached_updates __context =
     ignore(Helpers.call_api_functions ~__context
       (fun rpc session_id -> Client.Pool_update.detach ~rpc ~session_id ~self ~host))
   )
+
+let resync_host ~__context ~host =
+  let update_applied_dir = "/var/update/applied" in
+  if Sys.file_exists update_applied_dir then begin
+    debug "pool_update.resync_host scanning directory %s for applied updates" update_applied_dir;
+    let update_uuids = try Array.to_list (Sys.readdir update_applied_dir) with _ -> [] in
+    let updates = List.map (function update_uuid -> Db.Pool_update.get_by_uuid ~__context ~uuid:update_uuid) update_uuids in
+    Db.Host.set_updates ~__context ~self:host ~value:updates
+  end
+  else Db.Host.set_updates ~__context ~self:host ~value:[]
+


### PR DESCRIPTION
1. Check /var/update/applied and sync the applied updates.
2. Invoked when Xapi starts and when update is applied.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
