### PR TITLE
CP-18658: xenopsd tells us PVS_proxy.currently_attached

### DIFF
--- a/ocaml/xapi/pvs_proxy_control.ml
+++ b/ocaml/xapi/pvs_proxy_control.ml
@@ -124,8 +124,8 @@ let start_proxy ~__context vif proxy =
 		let site = Db.PVS_proxy.get_site ~__context ~self:proxy in
 		let sr, vdi = Xapi_pvs_cache.find_or_create_cache_vdi ~__context ~host ~site in
 		update_site_on_localhost ~__context ~site ~vdi ~starting_proxies:[vif, proxy] ();
-		Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:true;
-		Db.PVS_proxy.set_cache_SR ~__context ~self:proxy ~value:sr
+		Db.PVS_proxy.set_cache_SR ~__context ~self:proxy ~value:sr;
+		true
 	with e ->
 		let reason =
 			match e with
@@ -154,7 +154,8 @@ let start_proxy ~__context vif proxy =
 				"PVS proxy not licensed"
 			| _ -> Printf.sprintf "unknown error (%s)" (Printexc.to_string e)
 		in
-		warn "Unable to enable PVS proxy for VIF %s: %s. Continuing with proxy unattached." (Ref.string_of vif) reason
+		warn "Unable to enable PVS proxy for VIF %s: %s. Continuing with proxy unattached." (Ref.string_of vif) reason;
+		false
 
 let stop_proxy ~__context vif proxy =
 	if Db.PVS_proxy.get_currently_attached ~__context ~self:proxy then begin
@@ -163,7 +164,6 @@ let stop_proxy ~__context vif proxy =
 			let sr = Db.PVS_proxy.get_cache_SR ~__context ~self:proxy in
 			let vdi = Xapi_pvs_cache.find_cache_vdi ~__context ~sr in
 			update_site_on_localhost ~__context ~site ~vdi ~stopping_proxies:[vif, proxy] ();
-			Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:false;
 			Db.PVS_proxy.set_cache_SR ~__context ~self:proxy ~value:Ref.null
 		with e ->
 			let reason =
@@ -183,9 +183,10 @@ let find_proxy_for_vif ~__context ~vif =
 	| [] -> None
 	| proxy :: _ -> Some proxy
 
+(* Called on VM start *)
 let maybe_start_proxy_for_vif ~__context ~vif =
 	Opt.iter
-		(start_proxy ~__context vif)
+		(fun p -> start_proxy ~__context vif p |> ignore)
 		(find_proxy_for_vif ~__context ~vif)
 
 let maybe_stop_proxy_for_vif ~__context ~vif =

--- a/ocaml/xapi/pvs_proxy_control.mli
+++ b/ocaml/xapi/pvs_proxy_control.mli
@@ -15,7 +15,7 @@
 val proxy_port_name : string -> string
 val get_running_proxies : __context:Context.t -> site:API.ref_PVS_site -> API.ref_PVS_proxy list
 
-val start_proxy : __context:Context.t -> API.ref_VIF -> API.ref_PVS_proxy -> unit
+val start_proxy : __context:Context.t -> API.ref_VIF -> API.ref_PVS_proxy -> bool
 val stop_proxy : __context:Context.t -> API.ref_VIF -> API.ref_PVS_proxy -> unit
 
 val find_proxy_for_vif : __context:Context.t -> vif:API.ref_VIF -> API.ref_PVS_proxy option

--- a/ocaml/xapi/xapi_pvs_proxy.ml
+++ b/ocaml/xapi/xapi_pvs_proxy.ml
@@ -31,17 +31,18 @@ let create ~__context ~site ~vIF ~prepopulate =
 	Db.PVS_proxy.create ~__context
 		~ref:pvs_proxy ~uuid ~site ~vIF ~prepopulate ~currently_attached:false ~cache_SR:Ref.null;
 	if Db.VIF.get_currently_attached ~__context ~self:vIF then begin
-		Pvs_proxy_control.start_proxy ~__context vIF pvs_proxy;
-		if Db.PVS_proxy.get_currently_attached ~__context ~self:pvs_proxy then
+		if Pvs_proxy_control.start_proxy ~__context vIF pvs_proxy then
 			try
+				(* This will cause Pvs_proxy.currently_attached to become true. *)
 				Xapi_xenops.vif_set_pvs_proxy ~__context ~self:vIF true
-			with e ->
+			with e -> (
 				let body = Printf.sprintf "Failed to setup PVS-proxy %s for VIF %s due to an internal error"
 					uuid (Db.VIF.get_uuid ~__context ~self:vIF) in
 				let (name, priority) = Api_messages.pvs_proxy_setup_failed in
 				Helpers.call_api_functions ~__context (fun rpc session_id ->
 					ignore(Client.Client.Message.create ~rpc ~session_id ~name ~priority ~cls:`PVS_proxy ~obj_uuid:uuid ~body));
 				error "Unable to setup PVS proxy for vif %s: %s." (Ref.string_of vIF) (ExnHelper.string_of_exn e)
+			)
 	end;
 	pvs_proxy
 
@@ -57,6 +58,6 @@ let set_prepopulate ~__context ~self ~value =
 	Db.PVS_proxy.set_prepopulate ~__context ~self ~value;
 	if Db.PVS_proxy.get_currently_attached ~__context ~self then begin
 		let vif = Db.PVS_proxy.get_VIF ~__context ~self in
-		Pvs_proxy_control.start_proxy ~__context vif self
+		Pvs_proxy_control.start_proxy ~__context vif self |> ignore
 	end
 

--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1648,6 +1648,12 @@ let update_vif ~__context id =
 										Monitor_dbcalls_cache.clear_cache_for_pif ~pif_name
 									) pifs
 							end;
+							(match Pvs_proxy_control.find_proxy_for_vif ~__context ~vif with
+								| None -> ()
+								| Some proxy ->
+									debug "xenopsd event: Updating PVS_proxy for VIF %s.%s currently_attached <- %b" (fst id) (snd id) state.pvs_rules_active;
+									Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:state.pvs_rules_active
+							);
 							debug "xenopsd event: Updating VIF %s.%s currently_attached <- %b" (fst id) (snd id) (state.plugged || state.active);
 							Db.VIF.set_currently_attached ~__context ~self:vif ~value:(state.plugged || state.active)
 						) info;


### PR DESCRIPTION
Instead of setting PVS_proxy.currently_attached to true proactively
after setting up the site, now we set it to the value sent by xenopsd
as part of an update to the VIF state.

In turn, xenopsd watches xenstore for a node which is created or
deleted after the OVS rules for the PVS proxy have been set up or
removed, respectively.
