### PR TITLE
CA-215192: Expose vif-move to the CLI

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -5334,6 +5334,16 @@ let vif_unplug_force = call
   ~allowed_roles:_R_VM_ADMIN
   ()
 
+(* NOTE: Update release when merging to lcm branch *)
+let vif_move = call
+  ~name:"move"
+  ~in_product_since:rel_dundee
+  ~doc:"Move the specified VIF to the specified network, even while the VM is running"
+  ~params:[Ref _vif, "self", "The VIF to move";
+	   Ref _network, "network", "The network to move it to"]
+  ~allowed_roles:_R_VM_ADMIN
+  ()
+
 let vif_operations =
   Enum ("vif_operations", 
 	[ "attach", "Attempting to attach this VIF to a VM";
@@ -5459,7 +5469,7 @@ let vif =
       ~doccomments:[] 
       ~messages_default_allowed_roles:_R_VM_ADMIN
       ~doc_tags:[Networking]
-      ~messages:[vif_plug; vif_unplug; vif_unplug_force; vif_set_locking_mode;
+      ~messages:[vif_plug; vif_unplug; vif_unplug_force; vif_move; vif_set_locking_mode;
         vif_set_ipv4_allowed; vif_add_ipv4_allowed; vif_remove_ipv4_allowed; vif_set_ipv6_allowed; vif_add_ipv6_allowed; vif_remove_ipv6_allowed; 
 	vif_configure_ipv4; vif_configure_ipv6]
       ~contents:

--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -1998,6 +1998,14 @@ add a mapping of 'path' -> '/tmp', the command line should contain the argument 
       implementation=No_fd Cli_operations.vif_configure_ipv6;
       flags=[];
     };
+   "vif-move",
+    {
+      reqd=["uuid";"network-uuid"];
+      optn=[];
+      help="Move the VIF to another network.";
+      implementation=No_fd Cli_operations.vif_move;
+      flags=[];
+    };
    "vm-create",
     {
       reqd=["name-label"];

--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -1590,6 +1590,13 @@ let vif_configure_ipv6 printer rpc session_id params =
 	if mode = `Static && address = "" then failwith "Required parameter not found: address";
 	Client.VIF.configure_ipv6 rpc session_id vif mode address gateway
 
+let vif_move printer rpc session_id params =
+	let uuid = List.assoc "uuid" params in
+	let network_uuid = List.assoc "network-uuid" params in
+	let vif = Client.VIF.get_by_uuid rpc session_id uuid in
+	let network = Client.Network.get_by_uuid rpc session_id network_uuid in
+	Client.VIF.move rpc session_id vif network
+
 let net_create printer rpc session_id params =
 	let network = List.assoc "name-label" params in
 	let descr = List.assoc_default "name-description" params "" in

--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -2721,6 +2721,12 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
 		let unplug ~__context ~self = unplug_common ~__context ~self ~force:false
 		let unplug_force ~__context ~self = unplug_common ~__context ~self ~force:true
 
+		let move ~__context ~self ~network =
+			info "VIF.move: VIF = '%s' network = '%s'" (vif_uuid ~__context self) (network_uuid ~__context network);
+			let local_fn = Local.VIF.move ~self ~network in
+			let remote_fn = (fun session_id rpc -> Client.VIF.move rpc session_id self network) in
+			forward_vif_op ~local_fn ~__context ~self remote_fn
+
 		let set_locking_mode ~__context ~self ~value =
 			info "VIF.set_locking_mode: VIF = '%s'; value = '%s'" (vif_uuid ~__context self) (Record_util.vif_locking_mode_to_string value);
 			let local_fn = Local.VIF.set_locking_mode ~self ~value in

--- a/ocaml/xapi/xapi_network_attach_helpers.mli
+++ b/ocaml/xapi/xapi_network_attach_helpers.mli
@@ -37,6 +37,11 @@ val assert_no_slave :
   [ `PIF ] Ref.t ->
   unit
 
+(** Raises an exception if any network cannot be seen *)
+val assert_can_see_named_networks :
+  __context:Context.t ->
+  vm:[ `VM ]Ref.t -> host:[ `host ] Ref.t -> [ `network ] Ref.t list -> unit
+
 (** Raises an exception if the network cannot be attached. *)
 val assert_can_attach_network_on_host :
   __context:Context.t ->

--- a/ocaml/xapi/xapi_vif.mli
+++ b/ocaml/xapi/xapi_vif.mli
@@ -61,12 +61,20 @@ val destroy : __context:Context.t -> self:[ `VIF ] Ref.t -> unit
 (** {2 Helper Functions} *)
 
 (** Move a VIF to another Network. *)
-val move :
+val move_internal :
 	__context:Context.t ->
 	network:[ `network ] Ref.t ->
+	?active:bool ->
 	[ `VIF ] Ref.t ->
 	unit
-	
+
+(** Move a VIF to another Network. *)
+val move :
+	__context:Context.t ->
+	self:[ `VIF ] Ref.t ->
+	network:[ `network ] Ref.t ->
+	unit
+
 (** Throw error if the given operation is not in the list of allowed operations.
  *  Implemented by {!Xapi_vif_helpers.assert_operation_valid} *)
 val assert_operation_valid :

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -18,6 +18,7 @@
 open Xstringext
 open Printf
 open Xapi_vm_memory_constraints
+open Xapi_network_attach_helpers
 open Listext
 open Fun
 module XenAPI = Client.Client
@@ -276,73 +277,7 @@ let assert_can_see_networks ~__context ~self ~host =
 	let vifs = Db.VM.get_VIFs ~__context ~self in
 	let reqd_nets =
 		List.map (fun self -> Db.VIF.get_network ~__context ~self) vifs in
-
-	let is_network_available_on host net =
-		(* has the network been actualised by one or more PIFs? *)
-		let pifs = Db.Network.get_PIFs ~__context ~self:net in
-		if pifs <> [] then begin
-			(* network is only available if one of  *)
-			(* the PIFs connects to the target host *)
-			let hosts =
-				List.map (fun self -> Db.PIF.get_host ~__context ~self) pifs in
-			List.mem host hosts
-		end else begin
-			let other_config = Db.Network.get_other_config ~__context ~self:net in
-			if List.mem_assoc Xapi_globs.assume_network_is_shared other_config && (List.assoc Xapi_globs.assume_network_is_shared other_config = "true") then begin
-				debug "other_config:%s is set on Network %s" Xapi_globs.assume_network_is_shared (Ref.string_of net);
-				true
-			end else begin
-				(* find all the VIFs on this network and whose VM's are running. *)
-				(* XXX: in many environments this will perform O (Vms) calls to  *)
-				(* VM.getRecord. *)
-				let vifs = Db.Network.get_VIFs ~__context ~self:net in
-				let vms = List.map (fun self -> Db.VIF.get_VM ~__context ~self) vifs in
-				let vms = List.map (fun self -> Db.VM.get_record ~__context ~self) vms in
-				let vms = List.filter (fun vm -> vm.API.vM_power_state = `Running) vms in
-				let hosts = List.map (fun vm -> vm.API.vM_resident_on) vms in
-				(* either not pinned to any host OR pinned to this host already *)
-				hosts = [] || (List.mem host hosts)
-			end
-		end
-	in
-
-	let avail_nets = List.filter (is_network_available_on host) reqd_nets in
-	let not_available = List.set_difference reqd_nets avail_nets in
-
-	List.iter
-		(fun net -> warn "Host %s cannot see Network %s"
-			(Helpers.checknull
-				(fun () -> Db.Host.get_name_label ~__context ~self:host))
-			(Helpers.checknull
-				(fun () -> Db.Network.get_name_label ~__context ~self:net)))
-		not_available;
-	if not_available <> [] then
-		raise (Api_errors.Server_error (Api_errors.vm_requires_net, [
-			Ref.string_of self;
-			Ref.string_of (List.hd not_available)
-		]));
-
-	(* Also, for each of the available networks, we need to ensure that we can bring it
-	 * up on the specified host; i.e. it doesn't need an enslaved PIF. *)
-	List.iter
-		(fun network->
-			try
-				Xapi_network_attach_helpers.assert_can_attach_network_on_host
-					~__context
-					~self:network
-					~host
-			(* throw exception more appropriate to this context: *)
-			with exn ->
-				debug
-					"Caught exception while checking if network %s could be attached on host %s:%s"
-					(Ref.string_of network)
-					(Ref.string_of host)
-					(ExnHelper.string_of_exn exn);
-				raise (Api_errors.Server_error (
-					Api_errors.host_cannot_attach_network, [
-						Ref.string_of host; Ref.string_of network ]))
-		)
-		avail_nets
+	assert_can_see_named_networks ~__context ~vm:self ~host reqd_nets
 
 (* IOMMU (VT-d) is required iff the VM has any vGPUs which require PCI
  * passthrough. *)


### PR DESCRIPTION
Add vif-move command, including sanity checking that the
requested network can be seen from the host running the VM (if it's running)

Signed-off-by: Bob Ball bob.ball@citrix.com
