### PR TITLE
CA-221976: Fix PVS_proxy `currently-attached=true`

### DIFF
--- a/ocaml/xapi/xapi_xenops.ml
+++ b/ocaml/xapi/xapi_xenops.ml
@@ -1651,8 +1651,11 @@ let update_vif ~__context id =
 							(match Pvs_proxy_control.find_proxy_for_vif ~__context ~vif with
 								| None -> ()
 								| Some proxy ->
-									debug "xenopsd event: Updating PVS_proxy for VIF %s.%s currently_attached <- %b" (fst id) (snd id) state.pvs_rules_active;
-									Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:state.pvs_rules_active
+									if Pvs_proxy_control.start_proxy ~__context vif proxy then begin
+										debug "xenopsd event: Updating PVS_proxy for VIF %s.%s currently_attached <- %b" (fst id) (snd id) state.pvs_rules_active;
+										Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:state.pvs_rules_active
+									end
+									else Db.PVS_proxy.set_currently_attached ~__context ~self:proxy ~value:false
 							);
 							debug "xenopsd event: Updating VIF %s.%s currently_attached <- %b" (fst id) (snd id) (state.plugged || state.active);
 							Db.VIF.set_currently_attached ~__context ~self:vif ~value:(state.plugged || state.active)


### PR DESCRIPTION
Set PVS_proxy `currently-attached=true` only when
Pvs_proxy_control.start_proxy got succeeded.

Signed-off-by: Sharad Yadav sharad.yadav@citrix.com
