### PR TITLE
PVS-proxy monitor: process all files with a "pvsproxy-" prefix

### DIFF
--- a/ocaml/xapi/xapi_globs.ml
+++ b/ocaml/xapi/xapi_globs.ml
@@ -631,7 +631,7 @@ let cpu_info_features_hvm_key = "features_hvm"
 
 (** PVS proxy *)
 
-let pvs_proxy_metrics_path = "/dev/shm/metrics/pvsproxy"
+let pvs_proxy_metrics_path_prefix = "/dev/shm/metrics/pvsproxy-"
 let pvs_proxy_status_ds_name = "status"
 
 (** Path to trigger file for Network Reset. *)


### PR DESCRIPTION
The earlier assumption was that there was just one metrics file per host.
However, it turned out that we need one per proxy.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
