### PR TITLE
PVS-proxy: use uuid (not PVS_uuid) in remove_site

### DIFF
--- a/ocaml/xapi/pvs_proxy_control.ml
+++ b/ocaml/xapi/pvs_proxy_control.ml
@@ -117,7 +117,7 @@ let update_site_on_localhost ~__context ~site ~vdi ?(starting_proxies=[]) ?(stop
 let remove_site_on_localhost ~__context ~site =
   let open Network_interface.PVS_proxy in
   let dbg = Context.string_of_task __context in
-  let uuid = Db.PVS_site.get_PVS_uuid ~__context ~self:site in
+  let uuid = Db.PVS_site.get_uuid ~__context ~self:site in
   Network.Net.PVS_proxy.remove_site dbg uuid
 
 exception No_cache_sr_available


### PR DESCRIPTION
Signed-off-by: Rob Hoes rob.hoes@citrix.com
