### PR TITLE
CA-220801: don't strip generation-id on startup, revert CA-104674

### DIFF
--- a/ocaml/xapi/dbsync_master.ml
+++ b/ocaml/xapi/dbsync_master.ml
@@ -213,10 +213,6 @@ let update_env __context sync_keys =
      and reset the rest to Halted. *)
   reset_vms_running_on_missing_hosts ~__context;
 
-  (* CA-104674: see comment in Xapi_vm_helpers *)
-  switched_sync sync_keys "genid" (fun () ->
-    Xapi_vm_helpers.remove_superfluous_genids ~__context);
-
   (* Resets all Halted VMs to a known good state *)
   release_locks ~__context;
   (* Cancel tasks that were running on the master - by setting host=None we consider all tasks

--- a/ocaml/xapi/xapi_vm_helpers.ml
+++ b/ocaml/xapi/xapi_vm_helpers.ml
@@ -852,18 +852,3 @@ let vm_fresh_genid ~__context ~self =
 	Db.VM.set_generation_id ~__context ~self ~value:new_genid ;
 	new_genid
 
-(** CA-104674: we accidentally gave genids to all guests. This
-    function removes them from all VMs that aren't Win8 or Win2012. We
-    can tell that they are Win8/12 because they have vga=std in the
-    platform flag map. A bit of a hack, but it works. *)
-let remove_superfluous_genids ~__context =
-	Db.VM.get_all_records ~__context
-	|> List.filter (fun (_,vm) ->
-		try List.assoc "vga" vm.API.vM_platform <> "std" with _ -> true)
-	|> List.iter (fun (self,vm) ->
-		if vm.API.vM_generation_id <> "" then
-			begin
-				debug "Removing superfluous Generation ID (%s) from VM %s"
-					vm.API.vM_generation_id vm.API.vM_uuid ;
-				Db.VM.set_generation_id ~__context ~self ~value:""
-			end)


### PR DESCRIPTION
This commit removes code that strips the Generation ID from VMs during
the startup phase of xapi. This code was introduced as a hotfix for XS
6.2 to correct a bug where all VMs would get Generation IDs when in fact
only some needed them. The code uses a heuristic to detect Windows VMs.
This heuristic fails with the Xen Conversion Manager (XCM) which ships
as a Linux VM with a Generation ID. Stripping the ID prevents the VM to
resume over a restart of Xapi,

The latter problem is more severe than the former because by now all VMs
originating from XS 6.2 should have been corrected.

Signed-off-by: Christian Lindig christian.lindig@citrix.com
