### PR TITLE
CA-224318: Multiple after-apply-guidance is comma not space separated.

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -220,7 +220,7 @@ let parse_update_info xml =
       try
         match List.assoc "after-apply-guidance" attr with
         | "" -> []
-        | s ->  List.map guidance_from_string (String.split ' ' s)
+        | s ->  List.map guidance_from_string (String.split ',' s)
       with
       | _ -> []
     in


### PR DESCRIPTION
Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
