### PR TITLE
CA-225033: Use basename of key value

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -243,7 +243,7 @@ let parse_update_info xml =
       uuid = uuid;
       name_label = name_label;
       name_description = name_description;
-      key = key;
+      key = Filename.basename key;
       installation_size = installation_size;
       after_apply_guidance = guidance;
     } in


### PR DESCRIPTION
Use basename of the key to ensure the key is only imported from /etc/pki/rpm-gpg.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
