### PR TITLE
Revert "CA-223788: Make host as required for precheck and apply."

### DIFF
--- a/ocaml/xapi/cli_frontend.ml
+++ b/ocaml/xapi/cli_frontend.ml
@@ -916,7 +916,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
 
     "update-precheck",
     {
-      reqd=["uuid"; "host"];
+      reqd=["uuid"];
       optn=[];
       help="Execute the precheck stage of the selected update on the specified host.";
       implementation=No_fd Cli_operations.update_precheck;
@@ -925,7 +925,7 @@ let rec cmdtable_data : (string*cmd_spec) list =
 
     "update-apply",
     {
-      reqd=["uuid"; "host"];
+      reqd=["uuid"];
       optn=[];
       help="Apply the selected update to the specified host.";
       implementation=No_fd Cli_operations.update_apply;


### PR DESCRIPTION
This reverts commit 7ad15ac3abc2703c2fe73751ee0519e0ecef5e30.
But keep the refined help message.

Signed-off-by: Hui Zhang hui.zhang@citrix.com
