### PR TITLE
CA-223785: Pool_update.precheck does not return live-patching related info

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -3918,6 +3918,14 @@ let host_crashdump =
     ()
 
 (* New Ely pool update mechanism *)
+let livepatch_status =
+  Enum ("livepatch_status",
+        [
+          "ok_livepatch_complete", "An applicable live patch exists for every required component";
+          "ok_livepatch_incomplete", "An applicable live patch exists but it is not sufficient";
+          "ok", "There is no applicable live patch"
+        ])
+    
 
 let pool_update_after_apply_guidance =
   Enum ("update_after_apply_guidance",
@@ -3943,6 +3951,7 @@ let pool_update_precheck = call
     ~in_oss_since:None
     ~in_product_since:rel_ely
     ~params:[ Ref _pool_update, "self", "The update whose prechecks will be run"; Ref _host, "host", "The host to run the prechecks on." ]
+    ~result:(livepatch_status, "The precheck pool update")
     ~allowed_roles:_R_POOL_OP
     ~forward_to:(HostExtension "pool_update.precheck")
     ()

--- a/ocaml/xapi/xapi_pool_patch.ml
+++ b/ocaml/xapi/xapi_pool_patch.ml
@@ -131,7 +131,7 @@ let forward ~__context ~self f =
 
 (* precheck API call entrypoint *)
 let precheck ~__context ~self ~host =
-  forward ~__context ~self (Client.Pool_update.precheck ~host); ""
+  ignore (forward ~__context ~self (Client.Pool_update.precheck ~host)); ""
 
 let apply ~__context ~self ~host =
   forward ~__context ~self (Client.Pool_update.apply ~host); ""

--- a/scripts/extensions/pool_update.precheck
+++ b/scripts/extensions/pool_update.precheck
@@ -20,14 +20,13 @@ import xcp.logger
 TMP_DIR = '/tmp/'
 PATCH_PRECHECK_FAILED_UNKNOWN_ERROR = 'PATCH_PRECHECK_FAILED_UNKNOWN_ERROR'
 
-
 class PrecheckFailure(Exception):
     pass
 
 
-def success_message():
-    rpcparams = {'Status': 'Success', 'Value': None}
-    return xmlrpclib.dumps((rpcparams, ), '', True, allow_none=True)
+def success_message(result):
+    rpcparams = {'Status': 'Success', 'Value': result}
+    return xmlrpclib.dumps((rpcparams, ), '', True)
 
 
 def failure_message(code, params):
@@ -51,13 +50,14 @@ def parse_control_package(session, yum_url):
 
 
 def execute_precheck(session, control_package, yum_conf_file):
+    livepatch_dic = {'PATCH_PRECHECK_LIVEPATCH_COMPLETE': 'ok_livepatch_complete', 'PATCH_PRECHECK_LIVEPATCH_INCOMPLETE': 'ok_livepatch_incomplete', 'PATCH_PRECHECK_LIVEPATCH_NOT_APPLICABLE': 'ok'}
     cmd = ['yum', 'install', '-y', '--noplugins', '-c', yum_conf_file, control_package]
     p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
     p.wait()
     output = p.stdout.read()
     xcp.logger.info('pool_update.precheck %r returncode=%r output=%r', cmd, p.returncode, output)
+    lines = output.splitlines()
     if p.returncode != 0:
-        lines = output.splitlines()
         errorlines = [l for l in lines if l.startswith('Error: ')]
         if errorlines:
             errmsg = errorlines[-1].split(':', 1)[-1].strip()
@@ -65,7 +65,18 @@ def execute_precheck(session, control_package, yum_conf_file):
             errmsg = lines[-1]
         raise PrecheckFailure(
             'Install %s error: %s' % (control_package, errmsg))
-
+    else:
+        resultlines = [l for l in lines if l.startswith('<livepatch ')]
+        if resultlines:
+            result = resultlines[-1].split('\"')[1]
+            try:
+                return livepatch_dic[result]
+            except KeyError:
+                raise PrecheckFailure(
+                    'Install %s, precheck error: %s' % (control_package, result))
+        else:
+            return "ok"    
+        
 
 if __name__ == '__main__':
     xcp.logger.logToSyslog(level=logging.INFO)
@@ -103,10 +114,8 @@ if __name__ == '__main__':
         yum_url = config.get(update_package, 'baseurl')
 
         control_package = parse_control_package(session, yum_url)
-
-        execute_precheck(session, control_package, yum_conf_file)
-
-        print(success_message())
+        
+        print(success_message(execute_precheck(session, control_package, yum_conf_file)))
     except Exception as e:
         print(failure_message(PATCH_PRECHECK_FAILED_UNKNOWN_ERROR,
                               ['Precheck failed on host %s[uuid=%s]: %s' % (host_name_label ,host_uuid, e)]))


### PR DESCRIPTION
Change Pool_update.precheck return livepatch_status type, which is a
new enum type that reflects the three livepatch possibilities outlined
in the livepatch design document. These are:
    PATCH_PRECHECK_LIVEPATCH_COMPLETE
    PATCH_PRECHECK_LIVEPATCH_INCOMPLETE
    PATCH_PRECHECK_LIVEPATCH_NOT_APPLICABLE
These should be represented in the datamodel by a enum type with
possible values:
    ok_livepatch_complete
    ok_livepatch_incomplete
    ok

If it is not a live-patch, return "ok".

Signed-off-by: Liang Dai liang.dai1@citrix.com
