### PR TITLE
CA-226241: Raise exception in pool_update.introduce if free disk space smaller than 1MB

### DIFF
--- a/ocaml/xapi/xapi_pool_update.ml
+++ b/ocaml/xapi/xapi_pool_update.ml
@@ -347,6 +347,8 @@ let create_update_record ~__context ~update ~update_info ~vdi =
     ~vdi:vdi
 
 let introduce ~__context ~vdi =
+  (*If current disk free space is smaller than 1MB raise exception*)
+  assert_space_available ~multiplier:1L Xapi_globs.host_update_dir (Int64.mul 1024L 1024L);
   let update_info = extract_update_info ~__context ~vdi ~verify in
   ignore(Unixext.mkdir_safe Xapi_globs.host_update_dir 0o755);
   ignore(assert_space_available Xapi_globs.host_update_dir update_info.installation_size);


### PR DESCRIPTION
Raise exception in pool_update.introduce if free disk space smaller than 1MB

Signed-off-by: Cheng Zhang cheng.zhang@citrix.com
