### PR TITLE
Revert "CA-220506: Update rbac roles for network.attach_for_vm and ne…

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4802,7 +4802,7 @@ let network_attach_for_vm = call
 	]
 	~in_product_since:rel_tampa
 	~hide_from_docs:true
-	~allowed_roles:_R_VM_POWER_ADMIN
+	~allowed_roles:_R_POOL_OP
 	()
 
 let network_detach_for_vm = call
@@ -4814,7 +4814,7 @@ let network_detach_for_vm = call
 	]
 	~in_product_since:rel_tampa
 	~hide_from_docs:true
-	~allowed_roles:_R_VM_POWER_ADMIN
+	~allowed_roles:_R_POOL_OP
 	()
 
 (** A virtual network *)


### PR DESCRIPTION
…twork.detach_for_vm API calls."

Allowing `VM Power Admin` role to perform API call 'network.attach_for_vm'
doesn't fix the VM migration to be allowed to `VM Power Admin`.
VM migration internally uses `SR.scan` which is currently allowed to
`Pool operator`.

This reverts commit ffb2c17393940aacf6ea22b8dd3941affdc890b8.
