### PR TITLE
CA-226280: Fix the `cancel_fn` call on failed `check_cancelling`.

### DIFF
--- a/ocaml/xapi/task_server.ml
+++ b/ocaml/xapi/task_server.ml
@@ -225,7 +225,11 @@ module Task = functor (Interface : INTERFACE) -> struct
     Mutex.execute t.tm (fun () -> t.cancel <- cancel_fn :: t.cancel);
     Stdext.Pervasiveext.finally
       (fun () ->
-         check_cancelling t;
+         (try
+            check_cancelling t
+          with e ->
+            cancel_fn ();
+            raise e);
          f ()
       )
       (fun () -> Mutex.execute t.tm (fun () -> t.cancel <- List.tl t.cancel))


### PR DESCRIPTION
If `check_cancelling` fails then `cancel_fn` called with `with_cancel`
is removed from Task cancel list and `cancel_fn` is never getting executed.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>