### PR TITLE
CA-232277/SCTX-2434: Remove Copy_state from active_copy table on VDI …

### DIFF
--- a/ocaml/xapi/storage_migrate.ml
+++ b/ocaml/xapi/storage_migrate.ml
@@ -300,7 +300,9 @@ let copy' ~task ~dbg ~sr ~vdi ~url ~dest ~dest_vdi =
 				);
 			)
 			(fun () -> 
-				Remote.DP.destroy ~dbg ~dp:remote_dp ~allow_leak:false);
+				Remote.DP.destroy ~dbg ~dp:remote_dp ~allow_leak:false;
+				State.remove id State.active_copy
+			);
 
 		SMPERF.debug "mirror.copy: copy complete local_vdi:%s dest_vdi:%s" vdi dest_vdi;
 


### PR DESCRIPTION
…copy completion.

On VDI copy completion, Copy_state for VDI copied to destination host
persist on source Host filesystem `storage_mirrors_copy.json`.

If XAPI is restarted on source Host then it destroys the copied VDI
assuming an active_copy is still running.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>