### PR TITLE
CA-232307: Fix xe pool-dump-database on slave

### DIFF
--- a/ocaml/xapi/cli_operations.ml
+++ b/ocaml/xapi/cli_operations.ml
@@ -4095,9 +4095,11 @@ let host_backup fd printer rpc session_id params =
 let pool_dump_db fd printer rpc session_id params =
   let filename = List.assoc "file-name" params in
   let make_command task_id =
-    let prefix = uri_of_someone rpc session_id Master in
-    let uri = Printf.sprintf "%s%s?session_id=%s&task_id=%s"
-        prefix
+    let pool = List.hd (Client.Pool.get_all rpc session_id) in
+    let master = Client.Pool.get_master rpc session_id pool in
+    let master_address = Client.Host.get_address rpc session_id master in
+    let uri = Printf.sprintf "https://%s%s?session_id=%s&task_id=%s"
+        master_address
         Constants.pool_xml_db_sync (Ref.string_of session_id) (Ref.string_of task_id) in
     debug "%s" uri;
     HttpGet (filename, uri) in


### PR DESCRIPTION
Return a URI that has the full master IP in it, so that it always works, even
when called on a pool slave.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>