### PR TITLE
xapi.spec.in: Update version number to 1.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ xapi.spec: xapi.spec.in
 srpm: xapi.spec
 	mkdir -p $(RPM_SOURCESDIR) $(RPM_SPECSDIR) $(RPM_SRPMSDIR)
 	while ! [ -d .git ]; do cd ..; done; \
-	git archive --prefix=xapi-1.14.0/ --format=tar HEAD | bzip2 -z > $(RPM_SOURCESDIR)/xapi-1.14.0.tar.bz2 # xen-api/Makefile
+	git archive --prefix=xapi-1.14.1/ --format=tar HEAD | bzip2 -z > $(RPM_SOURCESDIR)/xapi-1.14.1.tar.bz2 # xen-api/Makefile
 	cp $(JQUERY) $(JQUERY_TREEVIEW) $(RPM_SOURCESDIR)
 	make -C $(REPO) version
 	rm -f $(RPM_SOURCESDIR)/xapi-version.patch

--- a/xapi.spec.in
+++ b/xapi.spec.in
@@ -2,7 +2,7 @@
 
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
-Version: 1.14.0
+Version: 1.14.1
 Release: @RPM_RELEASE@
 Group:   System/Hypervisor
 License: LGPL+linking exception


### PR DESCRIPTION
Update the version number to v1.14.1 before the release of xapi v1.14.1.
We should ensure that the version number in xapi.spec.in is in sync with
the version tags - the v1.14.1 tag should be at this commit, but not
before it.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>