### PR TITLE
CA-233580: allow control domains to start on disabled hosts.

### DIFF
--- a/ocaml/xapi/message_forwarding.ml
+++ b/ocaml/xapi/message_forwarding.ml
@@ -1210,6 +1210,7 @@ module Forward = functor(Local: Custom_actions.CUSTOM_ACTIONS) -> struct
       if Helpers.rolling_upgrade_in_progress ~__context
       then Helpers.assert_host_has_highest_version_in_pool
           ~__context ~host ;
+      Xapi_vm_helpers.assert_matches_control_domain_affinity ~__context ~self:vm ~host;
       (* Prevent VM start on a host that is evacuating *)
       List.iter (fun op ->
           match op with

--- a/ocaml/xapi/xapi_vm_lifecycle.ml
+++ b/ocaml/xapi/xapi_vm_lifecycle.ml
@@ -398,6 +398,7 @@ let check_operation_error ~__context ~vmr ~vmgmr ~ref ~clone_suspended_vm_enable
            && op <> `changing_memory_limits
            && op <> `changing_static_range
            && op <> `start
+           && op <> `start_on
            && op <> `changing_VCPUs
            && op <> `destroy
       then Some (Api_errors.operation_not_allowed, ["This operation is not allowed on a control domain"])


### PR DESCRIPTION
Also: allow operation start_on for control domains; ensure that a control domain
won't start on a host different from its affinity.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>