### PR TITLE
CA-210925: Added frontend_ro_.. call only present here

### DIFF
--- a/ocaml/xenops/cancel_utils.ml
+++ b/ocaml/xenops/cancel_utils.ml
@@ -51,7 +51,7 @@ let cancel_path_of ~xs = function
 	| TestPath x -> x
 
 let domain_shutdown_path_of ~xs = function
-	| Device device -> frontend_path_of_device ~xs device ^ "/tools/xenops/shutdown"
+	| Device device -> frontend_ro_path_of_device ~xs device ^ "/tools/xenops/shutdown"
 	| Domain domid -> Printf.sprintf "%s/tools/xenops/shutdown" (xs.Xs.getdomainpath domid)
 	| Qemu (backend, _) ->
 		(* We only need to cancel when the backend domain shuts down. It will


### PR DESCRIPTION
Commit 75a9a86e4e57b20040b597eb1beda850d91b9cb8 splits calls to
frontend_path_of_device into RW and RO versions. As that commit was
cherry-picked from cream-lcm, it missed a call to
frontend_path_of_device which only exists in clearwater-sp1.
This commit resolves this call to use the new RO version of the
function.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>