### PR TITLE
CA-237415: remove update group from yum

### DIFF
--- a/scripts/extensions/pool_update.apply
+++ b/scripts/extensions/pool_update.apply
@@ -63,6 +63,15 @@ def execute_apply(session, update_package, yum_conf_file):
             raise ApplyFailure(output)
 
 
+def remove_group(group):
+    cmd = ['yum', 'group', 'mark', 'remove', group]
+    p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True)
+    output, _ = p.communicate()
+    xcp.logger.info('pool_update.apply %r returncode=%r output=%r', cmd, p.returncode, output)
+    if p.returncode != 0:
+        raise ApplyFailure(output)
+
+
 if __name__ == '__main__':
     xcp.logger.logToSyslog(level=logging.INFO)
     txt = sys.stdin.read()
@@ -126,6 +135,7 @@ if __name__ == '__main__':
                 file.write("{0}".format(yum_conf))
 
             execute_apply(session, '@update', yum_conf_file)
+            remove_group('update')
 
             session.xenapi.pool_update.resync_host(host)
             print(success_message())


### PR DESCRIPTION
The commit 76070441 causes yum to add 'update' to the list of
groups. Attempting to reinstall an update then fails to install the
payload packages because yum believes the group to still be present.

Marking the group as removed fixes this.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>