### PR TITLE
CA-239839: VMs not showing memory statistics in rrd

### DIFF
--- a/ocaml/rrdd/rrdd_main.ml
+++ b/ocaml/rrdd/rrdd_main.ml
@@ -153,8 +153,12 @@ module Meminfo = struct
 				let meminfo_free = Int64.of_string (xs.Xs.read path) in
 				debug "memfree has changed to %Ld in domain %d" meminfo_free d;
 				current_meminfofree_values := IntMap.add d meminfo_free !current_meminfofree_values
-			with Xenbus.Xb.Noent ->
+			with
+			  Xenbus.Xb.Noent ->
 				debug "Couldn't read path %s; forgetting last known memfree value for domain %d" path d;
+				current_meminfofree_values := IntMap.remove d !current_meminfofree_values
+			| Failure("int_of_string") ->
+				debug "Couldn't parse meminfo_free value from path %s; forgetting last known memfree value for domain %d" path d;
 				current_meminfofree_values := IntMap.remove d !current_meminfofree_values
 
 	let watch_fired xc xs path domains _ =

--- a/ocaml/rrdd/rrdd_main.ml
+++ b/ocaml/rrdd/rrdd_main.ml
@@ -160,6 +160,9 @@ module Meminfo = struct
 			| Failure("int_of_string") ->
 				debug "Couldn't parse meminfo_free value from path %s; forgetting last known memfree value for domain %d" path d;
 				current_meminfofree_values := IntMap.remove d !current_meminfofree_values
+			| exn ->
+				error "Unexpected error: '%s' when reading path %s; forgetting last known memfree value for domain %d" (Printexc.to_string exn) path d;
+				current_meminfofree_values := IntMap.remove d !current_meminfofree_values
 
 	let watch_fired xc xs path domains _ =
 		match List.filter (fun x -> x <> "") (Stringext.String.split '/' path) with


### PR DESCRIPTION
When the `meminfo_free` field of the VM data in xenstore is not an Int, RRD `xenstore_watch` process fails and can get stuck in a loop.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>