### PR TITLE
CA-236863: division by 0 in VGPU-g detection

### DIFF
--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -491,18 +491,11 @@ module Intel = struct
             let vgpu_size =
               Constants.pgpu_default_size /// vgpus_per_pgpu
             in
-            let internal_config = let open Xapi_globs in
-              List.concat [
-                [ vgt_low_gm_sz, Int64.to_string conf.identifier.low_gm_sz
+            let internal_config = let open Xapi_globs in [ 
+                vgt_low_gm_sz, Int64.to_string conf.identifier.low_gm_sz
                 ; vgt_high_gm_sz, Int64.to_string conf.identifier.high_gm_sz
                 ; vgt_fence_sz, Int64.to_string conf.identifier.fence_sz
-                ]
-              ; match conf.identifier.monitor_config_file with
-                | Some monitor_config_file ->
-                  [vgt_monitor_config_file, monitor_config_file]
-                | None -> []
-              ]
-            in
+            ] in
             Some {
               vendor_name;
               model_name = conf.model_name;

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -491,6 +491,18 @@ module Intel = struct
             let vgpu_size =
               Constants.pgpu_default_size /// vgpus_per_pgpu
             in
+            let internal_config = let open Xapi_globs in
+              List.concat [
+                [ vgt_low_gm_sz, Int64.to_string conf.identifier.low_gm_sz
+                ; vgt_high_gm_sz, Int64.to_string conf.identifier.high_gm_sz
+                ; vgt_fence_sz, Int64.to_string conf.identifier.fence_sz
+                ]
+              ; match conf.identifier.monitor_config_file with
+                | Some monitor_config_file ->
+                  [vgt_monitor_config_file, monitor_config_file]
+                | None -> []
+              ]
+            in
             Some {
               vendor_name;
               model_name = conf.model_name;
@@ -499,16 +511,7 @@ module Intel = struct
               max_resolution_x = conf.max_x;
               max_resolution_y = conf.max_y;
               size = vgpu_size;
-              internal_config = [
-                Xapi_globs.vgt_low_gm_sz, Int64.to_string conf.identifier.low_gm_sz;
-                Xapi_globs.vgt_high_gm_sz, Int64.to_string conf.identifier.high_gm_sz;
-                Xapi_globs.vgt_fence_sz, Int64.to_string conf.identifier.fence_sz;
-              ] @ (
-                  match conf.identifier.monitor_config_file with
-                  | Some monitor_config_file ->
-                    [Xapi_globs.vgt_monitor_config_file, monitor_config_file]
-                  | None -> []
-                );
+              internal_config = internal_config;
               identifier = GVT_g conf.identifier;
               experimental = conf.experimental;
             })

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -480,8 +480,13 @@ module Intel = struct
             /// conf.identifier.low_gm_sz
             --- 1L
           in
-          if vgpus_per_pgpu <= 0L then
-            None
+          if vgpus_per_pgpu <= 0L then 
+            begin
+              warn "Not enough memory for Intel VGPUs. \
+                    If you intend to use them, increase the GPU \
+                    BAR size in the BIOS settings.";
+              None
+            end
           else
             let vgpu_size =
               Constants.pgpu_default_size /// vgpus_per_pgpu

--- a/ocaml/xapi/xapi_vgpu_type.ml
+++ b/ocaml/xapi/xapi_vgpu_type.ml
@@ -438,60 +438,76 @@ module Intel = struct
 				whitelist
 		end else []
 
-	let make_vgpu_types ~__context ~pci ~whitelist =
-		let open Xenops_interface.Pci in
-		let device_id =
-			Db.PCI.get_device_id ~__context ~self:pci
-			|> Xapi_pci.int_of_id
-		in
-		let address =
-			Db.PCI.get_pci_id ~__context ~self:pci
-			|> address_of_string
-		in
-		let whitelist = read_whitelist ~whitelist ~device_id in
-		let vendor_name, device =
-			Pci.(with_access (fun access ->
-				let vendor_name = lookup_vendor_name access intel_vendor_id in
-				let device =
-					List.find
-						(fun device ->
-							(device.Pci_dev.domain = address.domain) &&
-							(device.Pci_dev.bus = address.bus) &&
-							(device.Pci_dev.dev = address.dev) &&
-							(device.Pci_dev.func = address.fn))
-						(get_devices access)
-				in
-				vendor_name, device))
-		in
-		let bar_size =
-			List.nth device.Pci.Pci_dev.size 2
-			|> Int64.of_nativeint
-		in
-		List.map
-			Identifier.(fun conf ->
-				let vgpus_per_pgpu =
-					bar_size /// 1024L /// 1024L
-					/// conf.identifier.low_gm_sz
-					--- 1L
-				in
-				let vgpu_size = Constants.pgpu_default_size /// vgpus_per_pgpu in
-				{
-					vendor_name;
-					model_name = conf.model_name;
-					framebuffer_size = conf.framebufferlength;
-					max_heads = conf.num_heads;
-					max_resolution_x = conf.max_x;
-					max_resolution_y = conf.max_y;
-					size = vgpu_size;
-					internal_config = [
-						Xapi_globs.vgt_low_gm_sz, Int64.to_string conf.identifier.low_gm_sz;
-						Xapi_globs.vgt_high_gm_sz, Int64.to_string conf.identifier.high_gm_sz;
-						Xapi_globs.vgt_fence_sz, Int64.to_string conf.identifier.fence_sz;
-					];
-					identifier = GVT_g conf.identifier;
-					experimental = conf.experimental;
-				})
-			whitelist
+  let make_vgpu_types ~__context ~pci ~whitelist =
+    let open Xenops_interface.Pci in
+    let device_id =
+      Db.PCI.get_device_id ~__context ~self:pci
+      |> Xapi_pci.int_of_id
+    in
+    let address =
+      Db.PCI.get_pci_id ~__context ~self:pci
+      |> address_of_string
+    in
+    let whitelist = read_whitelist ~whitelist ~device_id in
+    let vendor_name, device =
+      Pci.(with_access (fun access ->
+          let vendor_name = lookup_vendor_name access intel_vendor_id in
+          let device =
+            List.find
+              (fun device ->
+                 (device.Pci_dev.domain = address.domain) &&
+                 (device.Pci_dev.bus = address.bus) &&
+                 (device.Pci_dev.dev = address.dev) &&
+                 (device.Pci_dev.func = address.fn))
+              (get_devices access)
+          in
+          vendor_name, device))
+    in
+    let bar_size =
+      List.nth device.Pci.Pci_dev.size 2
+      |> Int64.of_nativeint
+    in
+    let rec collect acc = function
+      | []             -> acc
+      | Some v :: tail -> collect (v :: acc) tail
+      | None   :: tail -> collect acc tail
+    in
+    whitelist
+    |> List.map
+      Identifier.(fun conf ->
+          let vgpus_per_pgpu =
+            bar_size /// 1024L /// 1024L
+            /// conf.identifier.low_gm_sz
+            --- 1L
+          in
+          if vgpus_per_pgpu <= 0L then
+            None
+          else
+            let vgpu_size =
+              Constants.pgpu_default_size /// vgpus_per_pgpu
+            in
+            Some {
+              vendor_name;
+              model_name = conf.model_name;
+              framebuffer_size = conf.framebufferlength;
+              max_heads = conf.num_heads;
+              max_resolution_x = conf.max_x;
+              max_resolution_y = conf.max_y;
+              size = vgpu_size;
+              internal_config = [
+                Xapi_globs.vgt_low_gm_sz, Int64.to_string conf.identifier.low_gm_sz;
+                Xapi_globs.vgt_high_gm_sz, Int64.to_string conf.identifier.high_gm_sz;
+                Xapi_globs.vgt_fence_sz, Int64.to_string conf.identifier.fence_sz;
+              ] @ (
+                  match conf.identifier.monitor_config_file with
+                  | Some monitor_config_file ->
+                    [Xapi_globs.vgt_monitor_config_file, monitor_config_file]
+                  | None -> []
+                );
+              identifier = GVT_g conf.identifier;
+              experimental = conf.experimental;
+            })
+    |> collect []
 
 	let find_or_create_supported_types ~__context ~pci
 			~is_system_display_device


### PR DESCRIPTION
Backported from trunk.

If the Intel GPU BAR size is too small, the number of VGPUs per PGPU
could become zero and give rise to a division by zero. This crashes the xapi initialisation leaving the server unresponsive. Currently the only solution was to figure out the issue and change the BIOS settings.

The suggested fix adds an intermediate check to the VGPU generation code to prevent
the division by zero from happening and adds an explicative warning in the log files.