### PR TITLE
CA-220506 backport: Update rbac roles for network.attach_for_vm and network.de…

### DIFF
--- a/ocaml/idl/datamodel.ml
+++ b/ocaml/idl/datamodel.ml
@@ -4802,7 +4802,7 @@ let network_attach_for_vm = call
 	]
 	~in_product_since:rel_tampa
 	~hide_from_docs:true
-	~allowed_roles:_R_POOL_OP
+	~allowed_roles:_R_VM_POWER_ADMIN
 	()
 
 let network_detach_for_vm = call
@@ -4814,7 +4814,7 @@ let network_detach_for_vm = call
 	]
 	~in_product_since:rel_tampa
 	~hide_from_docs:true
-	~allowed_roles:_R_POOL_OP
+	~allowed_roles:_R_VM_POWER_ADMIN
 	()
 
 (** A virtual network *)


### PR DESCRIPTION
…tach_for_vm API calls.

Allow VM_POWER_ADMIN and above roles to perform `network.attach_for_vm` and
`network.detach_for_vm` calls.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>
(cherry picked from commit ffb2c17393940aacf6ea22b8dd3941affdc890b8)

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>