### PR TITLE
CA-237543: Move management to new VLAN PIF on a Bond.create/destroy

### DIFF
--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -452,6 +452,9 @@ let destroy ~__context ~self =
 
       let local_vifs = get_local_vifs ~__context host [master_network] in
       let local_vlans = Db.PIF.get_VLAN_slave_of ~__context ~self:master in
+      let is_management_on_vlan =
+        List.filter (fun vlan -> Db.PIF.get_management ~__context ~self:(Db.VLAN.get_untagged_PIF ~__context ~self:vlan)) local_vlans <> []
+      in
       let local_tunnels = Db.PIF.get_tunnel_transport_PIF_of ~__context ~self:master in
 
       (* CA-86573: forbid the deletion of a bond involving the mgmt interface if HA is on *)
@@ -469,8 +472,10 @@ let destroy ~__context ~self =
         List.iter (fun pif -> if pif <> primary_slave then Nm.bring_pif_up ~__context pif) members
       end else begin
         (* Plug the members if the master was plugged *)
-        if plugged then
+        if plugged && not is_management_on_vlan then begin
+          debug "Plugging the bond members";
           List.iter (Nm.bring_pif_up ~__context) members
+        end
       end;
       TaskHelper.set_progress ~__context 0.2;
 
@@ -483,6 +488,13 @@ let destroy ~__context ~self =
       debug "Check VLANs to move from master to slaves";
       List.iter (move_vlan ~__context host primary_slave) local_vlans;
       TaskHelper.set_progress ~__context 0.6;
+
+      (* If management VLAN exist on a bond master then plug the members after moving management
+         from old vlan master to new vlan master *)
+      if is_management_on_vlan then begin
+        debug "Plugging the bond members after moving management from old vlan master to new vlan master";
+        List.iter (Nm.bring_pif_up ~__context) members
+      end;
 
       (* Move tunnels down *)
       debug "Check tunnels to move from master to slaves";

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -55,6 +55,15 @@ let move_configuration ~__context from_pif to_pif =
   Db.PIF.set_gateway ~__context ~self:from_pif ~value:"";
   Db.PIF.set_DNS ~__context ~self:from_pif ~value:""
 
+let move_management ~__context from_pif to_pif =
+  Nm.bring_pif_up ~__context ~management_interface:true to_pif;
+  let network = Db.PIF.get_network ~__context ~self:to_pif in
+  let bridge = Db.Network.get_bridge ~__context ~self:network in
+  let primary_address_type = Db.PIF.get_primary_address_type ~__context ~self:to_pif in
+  Xapi_host.change_management_interface ~__context bridge primary_address_type;
+  Xapi_pif.update_management_flags ~__context ~host:(Helpers.get_localhost ~__context)
+
+
 (* Determine local VIFs: candidates for moving to the bond.
  * Local VIFs are those VIFs on the given networks that belong to VMs that
  * are either running on the current host, or can only start on the current host or nowhere. *)
@@ -96,8 +105,9 @@ let move_vlan ~__context host new_slave old_vlan =
   let tag = Db.VLAN.get_tag ~__context ~self:old_vlan in
   let network = Db.PIF.get_network ~__context ~self:old_master in
   let plugged = Db.PIF.get_currently_attached ~__context ~self:old_master in
+  let is_management_pif = Db.PIF.get_management ~__context ~self:old_master in
 
-  if plugged then begin
+  if plugged && not is_management_pif then begin
     debug "Unplugging old VLAN";
     Nm.bring_pif_down ~__context old_master
   end;
@@ -125,6 +135,9 @@ let move_vlan ~__context host new_slave old_vlan =
       Xapi_vlan.create_internal ~__context ~host ~tagged_PIF:new_slave ~tag ~network ~device
   in
 
+  (* Copy the IP configuration from vlan old_master to new_master *)
+  move_configuration ~__context old_master new_master;
+
   (* Destroy old VLAN and VLAN-master objects *)
   debug "Destroying old VLAN %d" (Int64.to_int tag);
   Db.VLAN.destroy ~__context ~self:old_vlan;
@@ -132,9 +145,14 @@ let move_vlan ~__context host new_slave old_vlan =
 
   (* Plug again if plugged before the move *)
   if plugged then begin
-    debug "Plugging new VLAN";
-    Nm.bring_pif_up ~__context new_master;
-
+    if is_management_pif then begin
+      debug "Moving management from old VLAN to new VLAN";
+      move_management ~__context old_master new_master;
+    end
+    else begin
+     debug "Plugging new VLAN";
+     Nm.bring_pif_up ~__context new_master
+    end;
     (* Call Xapi_vif.move_internal on VIFs of running VMs to make sure they end up on the right vSwitch *)
     let vifs = Db.Network.get_VIFs ~__context ~self:network in
     let vifs = List.filter (fun vif ->
@@ -170,14 +188,6 @@ let move_tunnel ~__context host new_transport_PIF old_tunnel =
         vifs in
     ignore (List.map (Xapi_vif.move_internal ~__context ~network:network) vifs);
   end
-
-let move_management ~__context from_pif to_pif =
-  Nm.bring_pif_up ~__context ~management_interface:true to_pif;
-  let network = Db.PIF.get_network ~__context ~self:to_pif in
-  let bridge = Db.Network.get_bridge ~__context ~self:network in
-  let primary_address_type = Db.PIF.get_primary_address_type ~__context ~self:to_pif in
-  Xapi_host.change_management_interface ~__context bridge primary_address_type;
-  Xapi_pif.update_management_flags ~__context ~host:(Helpers.get_localhost ~__context)
 
 let fix_bond ~__context ~bond =
   let bond_rec = Db.Bond.get_record ~__context ~self:bond in
@@ -277,6 +287,10 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
       let local_vifs = get_local_vifs ~__context host member_networks in
       let local_vlans = List.concat (List.map (fun pif -> Db.PIF.get_VLAN_slave_of ~__context ~self:pif) members) in
       let local_tunnels = List.concat (List.map (fun pif -> Db.PIF.get_tunnel_transport_PIF_of ~__context ~self:pif) members) in
+
+      let is_management_on_vlan =
+        List.filter (fun vlan -> Db.PIF.get_management ~__context ~self:(Db.VLAN.get_untagged_PIF ~__context ~self:vlan)) local_vlans <> []
+      in
 
       let management_pif =
         match List.filter (fun p -> Db.PIF.get_management ~__context ~self:p) members with
@@ -379,8 +393,12 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
           debug "Moving management from slave to master";
           move_management ~__context management_pif master
         | None ->
-          debug "Plugging the bond";
-          Nm.bring_pif_up ~__context master
+          (* If management VLAN exist on a bond member then plug the bond
+             after moving management from old vlan master to new vlan master *)
+          if not is_management_on_vlan then begin
+            debug "Plugging the bond";
+            Nm.bring_pif_up ~__context master
+          end
       end;
       TaskHelper.set_progress ~__context 0.2;
 
@@ -388,6 +406,15 @@ let create ~__context ~network ~members ~mAC ~mode ~properties =
       debug "Check VLANs to move from slaves to master";
       List.iter (move_vlan ~__context host master) local_vlans;
       TaskHelper.set_progress ~__context 0.4;
+
+      (* If management VLAN exist on a bond member then plugging the bond before moving management
+         from old vlan master to new vlan master destroys the vlan bridge.
+         This results the Host to be out of vlan network, Which is costly during Pool.join
+         Synchronising bonds step. It can force a slave to not able to contact the master permanently. *)
+      if is_management_on_vlan then begin
+        debug "Plugging the bond after moving management from old vlan master to new vlan master";
+        Nm.bring_pif_up ~__context master
+      end;
 
       (* Move tunnels from members to master *)
       debug "Check tunnels to move from slaves to master";

--- a/ocaml/xapi/xapi_bond.ml
+++ b/ocaml/xapi/xapi_bond.ml
@@ -479,15 +479,10 @@ let destroy ~__context ~self =
       end;
       TaskHelper.set_progress ~__context 0.2;
 
-      (* Move VIFs from master to slaves *)
-      debug "Check VIFs to move from master to slaves";
-      List.iter (Xapi_vif.move_internal ~__context ~network:primary_slave_network) local_vifs;
-      TaskHelper.set_progress ~__context 0.4;
-
       (* Move VLANs down *)
       debug "Check VLANs to move from master to slaves";
       List.iter (move_vlan ~__context host primary_slave) local_vlans;
-      TaskHelper.set_progress ~__context 0.6;
+      TaskHelper.set_progress ~__context 0.4;
 
       (* If management VLAN exist on a bond master then plug the members after moving management
          from old vlan master to new vlan master *)
@@ -495,6 +490,11 @@ let destroy ~__context ~self =
         debug "Plugging the bond members after moving management from old vlan master to new vlan master";
         List.iter (Nm.bring_pif_up ~__context) members
       end;
+
+      (* Move VIFs from master to slaves *)
+      debug "Check VIFs to move from master to slaves";
+      List.iter (Xapi_vif.move_internal ~__context ~network:primary_slave_network) local_vifs;
+      TaskHelper.set_progress ~__context 0.6;
 
       (* Move tunnels down *)
       debug "Check tunnels to move from master to slaves";


### PR DESCRIPTION
If Management VLAN exists on a bond member pif then:
1) Move the IP configuration to new vlan pif.
2) Move the management to the new vlan pif.
3) Skip `bring_pif_down call for old vlan pif.

Move the management from old vlan pif to new vlan pif
before bringing up the Bond PIF. In order to keep the vlan bridge
up during bond.create

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>