### PR TITLE
CP-22034: read PIF speed & duplex from sysfs

### DIFF
--- a/ocaml/network/link_stubs.c
+++ b/ocaml/network/link_stubs.c
@@ -137,43 +137,6 @@ struct ethtool_cmd {
 	uint32_t reserved[4];
 };
 
-value stub_link_get_status(value fd, value dev)
-{
-	CAMLparam2(fd, dev);
-	CAMLlocal1(ret);
-	struct ifreq ifr;
-	struct ethtool_cmd ecmd;
-	int err, speed, duplex;
-
-	SET_IFREQ(ifr, String_val(dev));
-	ecmd.cmd = ETHTOOL_GSET;
-	ifr.ifr_data = (caddr_t) &ecmd;
-	err = ioctl(Int_val(fd), SIOCETHTOOL, &ifr);
-	CHECK_IOCTL(err, "get ethtool");
-
-	/* CA-24610: apparently speeds can be other values eg 2500 */
-	speed = ecmd.speed;
-
-	switch (ecmd.duplex) {
-	case 0: duplex = 1; break;
-	case 1: duplex = 2; break;
-	default: duplex = 0;
-	}
-
-	ret = caml_alloc_tuple(2);
-	Store_field(ret, 0, Val_int(speed));
-	Store_field(ret, 1, Val_int(duplex));
-
-	CAMLreturn(ret);
-}
 #else
-value stub_link_get_status(value fd, value dev)
-{
-	CAMLparam2(fd, dev);
-	CAMLlocal1(ret);
-	ret = caml_alloc_tuple(2);
-	Store_field(ret, 0, Val_int(0)); /* unknown speed */
-	Store_field(ret, 1, Val_int(0)); /* unknown duplex */
-	CAMLreturn(ret);
-}
+/* nothing here at present */
 #endif

--- a/ocaml/network/network_monitor_thread.ml
+++ b/ocaml/network/network_monitor_thread.ml
@@ -181,7 +181,7 @@ let rec monitor dbg () =
 							if not carrier then
 								speed, duplex
 							else
-								let speed', duplex' = Bindings.get_status dev in
+								let speed', duplex' = Sysfs.get_status dev in
 								speed + speed', combine_duplex (duplex, duplex')
 						with _ ->
 							speed, duplex

--- a/ocaml/network/network_utils.ml
+++ b/ocaml/network/network_utils.ml
@@ -170,6 +170,18 @@ module Sysfs = struct
 	let get_all_bridges () =
 		let ifaces = list () in
 		List.filter (fun name -> Sys.file_exists (getpath name "bridge")) ifaces
+
+	(** Returns (speed, duplex) for a given network interface: int megabits/s, Duplex.
+	 *  The units of speed are specified in pif_record in xen-api/xapi/records.ml.
+	 *  Note: these data are present in sysfs from kernel 2.6.33. *)
+	let get_status name =
+		let speed = getpath name "speed"
+		|> (fun p -> try (read_one_line p |> int_of_string) with _ -> 0)
+		in
+		let duplex = getpath name "duplex"
+		|> (fun p -> try read_one_line p |> duplex_of_string with _ -> Duplex_unknown)
+		in (speed, duplex)
+
 end
 
 module Ip = struct
@@ -937,40 +949,6 @@ module Ethtool = struct
 	let set_offload name options =
 		if options <> [] then
 			ignore (call ~log:true ("-K" :: name :: (List.concat (List.map (fun (k, v) -> [k; v]) options))))
-end
-
-module Bindings = struct
-	let control_socket () =
-		try
-			Unix.socket Unix.PF_INET Unix.SOCK_DGRAM 0
-		with
-		exn ->
-			try
-				Unix.socket Unix.PF_UNIX Unix.SOCK_DGRAM 0
-			with
-			exn ->
-				Unix.socket Unix.PF_INET6 Unix.SOCK_DGRAM 0
-
-	let with_fd f =
-		let fd = control_socket () in
-		let r = begin try
-			f fd
-		with
-		exn ->
-			Unix.close fd;
-			raise exn
-		end in
-		Unix.close fd;
-		r
-
-	external _get_status : Unix.file_descr -> string -> int * duplex = "stub_link_get_status"
-
-	(** Returns speed and duplex for a given network interface.
-	 *  Note: from kernel 2.6.33, this information is also present in sysfs. *)
-	let get_status name =
-		try
-			with_fd (fun fd -> _get_status fd name)
-		with _ -> raise (Read_error "stub_link_get_status")
 end
 
 module Dhcp6c = struct


### PR DESCRIPTION
Sisyphus can tell us these details nowadays, so we can read them
from the relevant files rather than going through the C bindings.

The existing C bindings cannot cope with speeds such as
50 Gbits/second and higher.

Therefore this commit removes the get_status functions from the
C stub and removes the Bindings module that uses it, and adds a
replacement get_status function in the Sysfs module; it returns
the same (speed, duplex) pair as the old function.

Signed-off-by: Thomas Sanders <thomas.sanders@citrix.com>
(cherry picked from commit 2eeb50c3c9871e67c53501f4dc2fa3f23a6eda21
 in repository xcp-networkd)

Conflicts:

	networkd/network_monitor_thread.ml
	ocaml/network/network_utils.ml