### PR TITLE
CA-252876: AD group name with parenthesis not work as expect in XenSe…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script: bash travis-build-repo.sh
 sudo: true
 env:
     global:
+        - GIT_BRANCH=dundee-bugfix
         - REPO_PACKAGE_NAME=xapi
         - REPO_CONFIGURE_CMD=./configure
         - REPO_BUILD_CMD=make

--- a/ocaml/test/OMakefile
+++ b/ocaml/test/OMakefile
@@ -11,6 +11,7 @@ OCAMLINCLUDES = \
 	../idl/ocaml_backend \
 	../autogen \
 	../license \
+	../auth \
 
 OCAML_LIBS = \
 	../util/version \
@@ -61,6 +62,7 @@ OCAML_OBJS = \
 	../license/daily_license_check \
 	test_daily_license_check \
 	test_dbsync_master \
+	test_extauth_plugin_ADpbis \
 
 OCamlProgram(suite, suite $(OCAML_OBJS) )
 

--- a/ocaml/test/suite.ml
+++ b/ocaml/test/suite.ml
@@ -50,6 +50,7 @@ let base_suite =
 			(* Test_ca121350.test; *)
 			Test_daily_license_check.test;
 			Test_dbsync_master.test;
+			Test_extauth_plugin_ADpbis.test;
 		]
 
 let handlers = [

--- a/ocaml/test/test_extauth_plugin_ADpbis.ml
+++ b/ocaml/test/test_extauth_plugin_ADpbis.ml
@@ -1,0 +1,58 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open OUnit
+open Test_highlevel
+
+module PbisExtractSid = Generic.Make(struct
+    module Io = struct
+      type input_t = (string * string) list
+      type output_t = string list
+
+      let string_of_input_t = Test_printers.(list (pair string string))
+      let string_of_output_t = Test_printers.(list string)
+    end
+
+    let transform = Extauth_plugin_ADpbis.extract_sid_from_group_list
+
+    let tests = [
+      [(" ", " ")], [];
+
+      [("Exception","Remote connection shutdown!")], [];
+
+      [("Number of groups found for user 'testAD@BLE'", "0");
+       ("Error", "No record found")],
+      [];
+
+      [("Number of groups found for user 'admin@NVC'", "1");
+       ("", "Group[1 of 1] name = NVC\\testg(ab) (gid = 564135020, sid = S-1-5-21-1171552557-368733809-2946345504-1132)")],
+      ["S-1-5-21-1171552557-368733809-2946345504-1132"];
+
+      [("Number of groups found for user 'cnk3@UN'", "1");
+       ("", "Group[1 of 1] name = UN\\KnmOJ (gid = 492513842, sid = S-1-5-31-5921451325-154521381-3135732118-4527)")],
+      ["S-1-5-31-5921451325-154521381-3135732118-4527"];
+
+      [("Number of groups found for user 'test@testdomain'", "2");
+       ("", "Group[1 of 2] name = testdomain\\dnsadmins (gid = 580912206, sid = S-1-5-21-791009147-1041474540-2433379237-1102)");
+       ("", "Group[2 of 2] name = testdomain\\domain+users (gid = 580911617, sid = S-1-5-21-791009147-1041474540-2433379237-513)")],
+      ["S-1-5-21-791009147-1041474540-2433379237-1102"; "S-1-5-21-791009147-1041474540-2433379237-513"];
+    ]
+  end)
+
+let test =
+  "test_extauth_ADpbis" >:::
+  [
+    "test_pbis_extract_sid" >::: PbisExtractSid.tests;
+  ]
+


### PR DESCRIPTION
…rver 7.0 pool

This also fixes CP-22274 Replace string_trim with built-in String.trim

Signed-off-by: Liang Dai <liang.dai1@citrix.com>

(cherry picked from commit b445af3aa03d189fbb87f121f33b41d2ad97641c)
Conflicts:
     ocaml/auth/extauth_plugin_ADpbis.ml
     ocaml/xapi/test_extauth_plugin_ADpbis.ml

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>

(cherry picked from commit 734cf7eb4c1dc6c443f590d0e9533e192527e5f5, which itself
was cherry-picked from commit b445af3aa03d189fbb87f121f33b41d2ad97641c)

The use of `string_trim` was preserved here because `String.trim` does not seem to
exist; this should have no effect on the fix, and the tests still pass.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>